### PR TITLE
Don't anticipate error attributes in input

### DIFF
--- a/test/test_model.py
+++ b/test/test_model.py
@@ -657,12 +657,6 @@ class TestModel(unittest.TestCase):
         Test the tile-by-tile simulation.
         """
         # Test invalid responses
-        non_response1 = {
-            "error": {  # Contains the "error" key
-                "message": "boom!",
-                "trace": "blah at line 2"
-            }
-        }
         non_response2 = {
             "result": {  # No "distribution" key
                 "cell_count": 1
@@ -673,7 +667,6 @@ class TestModel(unittest.TestCase):
                 "distribution": {}
             }
         }
-        self.assertRaises(Exception, simulate_all_tiles, (date.today(), non_response1))
         self.assertRaises(Exception, simulate_all_tiles, (date.today(), non_response2))
         self.assertRaises(Exception, simulate_all_tiles, (date.today(), non_response3))
 

--- a/tr55/model.py
+++ b/tr55/model.py
@@ -166,9 +166,7 @@ def simulate_all_tiles(parameters, tile_census, pre_columbian=False):
     The output is a runoff, evapotranspiration, infiltration triple
     which is an average of those produced by all of the tiles.
     """
-    if 'error' in tile_census:
-        raise Exception('No "error" key')
-    elif 'result' not in tile_census:
+    if 'result' not in tile_census:
         raise Exception('No "result" key')
     elif 'cell_count' not in tile_census['result']:
         raise Exception('No "result.cell_count" key')


### PR DESCRIPTION
The error attribute test for was specific to a particular implementation
of generating the input.  Shouldn't anticipate all implementations
specifying one if their input generation failed.

Fixes #13
