### PR TITLE
Add support for source and binary Python package distributions

### DIFF
--- a/DESCRIPTION.rst
+++ b/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+A Python implementation of TR-55.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include DESCRIPTION.rst
+
+recursive-include test *

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+
+from setuptools import setup, find_packages
+from codecs import open
+from os import path
+
+# Get the long description from DESCRIPTION.rst
+with open(path.join(path.abspath(path.dirname(__file__)),
+          'DESCRIPTION.rst'), encoding='utf-8') as f:
+    long_description = f.read()
+
+setup(
+    name='tr55',
+    version='0.1.0.dev1',
+    description='A Python implementation of TR-55.',
+    long_description=long_description,
+    url='https://github.com/azavea/tr-55',
+    author='Azavea Inc.',
+    # TODO Pick a license. Also, add it to classifiers.
+    # See also: https://github.com/azavea/tr-55/issues/6
+    license='',
+    # TODO Determine Python version support
+    # See also: https://github.com/azavea/tr-55/issues/16
+    classifiers=[
+        'Development Status :: 1 - Planning',
+        'Intended Audience :: Developers',
+        'Intended Audience :: Education',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3',
+    ],
+    keywords='tr-55 watershed hydrology',
+    packages=find_packages(exclude=['tests']),
+    install_requires=[],
+    extras_require={
+        'dev': [],
+        'test': ['nose==1.3.4'],
+    },
+)


### PR DESCRIPTION
This is based on the outline provided by the Python Packaging User Guide:

  https://packaging.python.org/en/latest/distributing.html

The goal is for this work to support building and uploading package distributions directly to PyPI from Travis CI. Adding something like:

``` yaml
distributions: "sdist bdist_wheel"
```

To the PyPI `deploy` provider should handle most of the process.

Also, for building local binary distributions, the `wheel` package must be installed.

Attempts to resolve #4.
