### PR TITLE
Initial travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: python
+python:
+- '2.7'
+install: pip install -r requirements.txt --use-mirrors
+script: python setup.py test
+deploy:
+  provider: pypi
+  user: azavea
+  password:
+    secure: K/6De0BdqcYyzzrw2hz6A3vOJH1YWTEmK7TKOCviDeX0VmlDXW5KiB/3i0NbYXZtM/89Mi1H+pg6mXUdCGf5LIevN54lA+/8VJK5zBN4TXzz+uYqxIYzxGg4oTWMiQxim0TwhDl/887gWDGsbO/0yx658GivvN9skAd0bm3HjYk=
+  distributions: "sdist bdist_wheel"
+  on:
+    tags: true
+    repo: WikiWatershed/tr-55


### PR DESCRIPTION
Sets up a Travis CI job to run the TR-55 tests and deploy the package to PyPI on tagged commits to the `deploy` branch of this repo.  Eventually we'll want to update this to only deploy a new version for tagged commits to a production branch.

* Tested for python 3 support, which fails.  You can see some initial work to get it passing in https://github.com/mmcfarland/tr-55/commit/0771f2d3572f7a6b64e07e898f5ca8bafb303a1f but I'm leaving completion of that for a different issue
* I did not include linting for the same reason
* Deployment was tested sucessfully when this was configured for a test fork, after merging, I'll confirm that the deployment works in this repo and follow up with a README PR that instructs how to make deployments.

Connects #5 