### PR TITLE
Add support for running Nose test suite in setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ should produce the following output:
 
 ## Testing
 
-Run `nosetests` from within the project directory.
+Run `python setup.py test` from within the project directory.
 
 ## License
 This project is licensed under the terms of the Apache 2.0 license.

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,8 @@ with open(path.join(path.abspath(path.dirname(__file__)),
           'DESCRIPTION.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
+tests_require = ['nose >= 1.3.4']
+
 setup(
     name='tr55',
     version='0.1.0.dev1',
@@ -32,6 +34,8 @@ setup(
     install_requires=[],
     extras_require={
         'dev': [],
-        'test': ['nose==1.3.4'],
+        'test': tests_require,
     },
+    test_suite='nose.collector',
+    tests_require=tests_require,
 )


### PR DESCRIPTION
This changeset instructs `setuptools` to run the Nose test suite as the default. Running `python setup.py test` should now execute the Nose test suite.

Attempts to resolve #23.