### PR TITLE
Increment sub-version for module for deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+## 0.1.0.dev2
+- Initial development release

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 A Python implementation of TR-55.
 
+## Installation
+You can install the latest version from PyPI
+```bash
+pip install tr55
+```
+
 ## Functions
 
 `simulate_day`, `simulate_year`, `simulate_modifications` are the three functions most likely to be of direct interest for users of this module.
@@ -177,6 +183,21 @@ should produce the following output:
 ## Testing
 
 Run `python setup.py test` from within the project directory.
+
+
+## Deployments
+Deployments to PyPi are handled through [Travis-CI](https://travis-ci.org/WikiWatershed/tr-55). The following git flow commands approximate a release using Travis:
+
+``` bash
+$ git flow release start 0.1.0
+$ vim CHANGELOG.md
+$ git commit -m "0.1.0"
+$ git flow release publish 0.1.0
+$ git flow release finish 0.1.0
+```
+
+To kick off the deployment, you'll still need to push the local tags remotely
+`git push --tags`
 
 ## License
 This project is licensed under the terms of the Apache 2.0 license.

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ tests_require = ['nose >= 1.3.4']
 
 setup(
     name='tr55',
-    version='0.1.0.dev1',
+    version='0.1.0.dev2',
     description='A Python implementation of TR-55.',
     long_description=long_description,
     url='https://github.com/azavea/tr-55',


### PR DESCRIPTION
This allows a new version of the module to be deployed to PyPI via the
Travis CI job.  This release is still just for testing purposes.