### PR TITLE
Fix NLCD codes.

### DIFF
--- a/tr55/tables.py
+++ b/tr55/tables.py
@@ -383,7 +383,7 @@ SAMPLE_YEAR = [
 # industrial, transportation). Describes the NLCD class value, the landscape
 # factor (ki) and the Curve Numbers for each hydrologic soil group for that use
 # type.
-# NOTE: Missing NLCD types 12 & 52 (plus all Alaska only types (51, 72-74)
+# NOTE: Missing NLCD type 12 (plus all Alaska only types (51, 72-74)
 LAND_USE_VALUES = {
     'water':                {'nlcd': 11, 'ki': 0.0, 'cn': {'a': 100, 'b': 100, 'c': 100, 'd': 100}},  # noqa
     'li_residential':       {'nlcd': 22, 'ki': 0.42, 'cn': {'a': 51, 'b': 68, 'c': 79, 'd': 84}},  # noqa
@@ -404,10 +404,10 @@ LAND_USE_VALUES = {
     'urban_grass':          {'nlcd': 21, 'ki': 0.7, 'cn': {'a': 68, 'b': 79, 'c': 86, 'd': 89}},  # noqa
     'woody_wetland':        {'nlcd': 90, 'ki': 1, 'cn': {'a': 98, 'b': 98, 'c': 98, 'd': 98}},  # noqa
     'herbaceous_wetland':   {'nlcd': 95, 'ki': 1, 'cn': {'a': 98, 'b': 98, 'c': 98, 'd': 98}},  # noqa
-    'chaparral':            {'nlcd': 95, 'ki': 1, 'cn': {'a': 98, 'b': 98, 'c': 98, 'd': 98}},  # noqa
-    'tall_grass_prairie':   {'nlcd': 95, 'ki': 1, 'cn': {'a': 98, 'b': 98, 'c': 98, 'd': 98}},  # noqa
-    'short_grass_prairie':  {'nlcd': 95, 'ki': 1, 'cn': {'a': 98, 'b': 98, 'c': 98, 'd': 98}},  # noqa
-    'desert':               {'nlcd': 95, 'ki': 1, 'cn': {'a': 98, 'b': 98, 'c': 98, 'd': 98}},  # noqa
+    'chaparral':            {'nlcd': 52, 'ki': 1, 'cn': {'a': 35, 'b': 56, 'c': 70, 'd': 77}},  # noqa
+    'tall_grass_prairie':   {'nlcd': 21, 'ki': 0.7, 'cn': {'a': 68, 'b': 79, 'c': 86, 'd': 89}},  # noqa
+    'short_grass_prairie':  {'nlcd': 81, 'ki': 0.6, 'cn': {'a': 39, 'b': 61, 'c': 74, 'd': 80}},  # noqa
+    'desert':               {'nlcd': 31, 'ki': 0.0, 'cn': {'a': 77, 'b': 86, 'c': 86, 'd': 91}},  # noqa
 
     'green_roof':           {'ki': 0.4, 'infiltration': {'a': 1.6, 'b': 1.6, 'c': 1.6, 'd': 1.6}},  # noqa
     'porous_paving':        {'ki': 0.0, 'infiltration': {'a': 7.73, 'b': 4.13, 'c': 1.73}},  # noqa


### PR DESCRIPTION
Some NLCD codes were incorrect.  "Short grass" is of type 81 [1], "chaparral" is of type 52 [2], "desert" is of type 31 [2], and "tall grass" is of type 21 [1].

[1] http://www.asprs.org/a/publications/pers/2003journal/december/2003_dec_1387-1397.pdf p. 1389
[2] http://www.mrlc.gov/nlcd11_leg.php