### PR TITLE
Change input format.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,20 @@ You can install the latest version from PyPI
 pip install tr55
 ```
 
-## Functions
+`simulate_year` and `simulate_day` are the two functions most likely to be of direct interest for users of this module.
+`simulate_cell_year`, `simulate_water_quality`, and `simulate_modifications` are three other functions which can be used to create simulations with additional behaviors beyond those supplied by `simulate_day` and `simulate_year`.
 
-`simulate_cell_year`, `simulate_water_quality`, and `simulate_modifications` are the three functions most likely to be of direct interest for users of this module.
+## Functions for Normal Use
+
+### `simulate_year`
+
+This function takes three arguments: a census of the area of interest, an optional cell resolution, and an optimal boolean parameter which determines whether the simulation is done under Pre-Columbian conditions.
+
+### `simulate_day`
+
+This function takes three arguments: a census of the area of interest (see the description given below in the discussion of `simulate_modifications`), an amount of precipitation in inches, and an optional cell resolution (the size of a cell in square meters).
+
+## Functions for Custom Scenarios
 
 ### `simulate_cell_year`
 
@@ -70,14 +81,14 @@ This function is used to simulate the effects of land use modifications.  The ar
        },
        "modifications": [
            {
-               "bmp": "no_till",
+               "change": "::no_till",
                "cell_count": 1,
                "distribution": {
                    "a:deciduous_forest": {"cell_count": 1},
                }
            },
            {
-               "reclassification": "d:rock",
+               "change": "d:rock:",
                "cell_count": 1,
                "distribution": {
                    "a:deciduous_forest": {"cell_count": 1}
@@ -87,17 +98,15 @@ This function is used to simulate the effects of land use modifications.  The ar
    }
    ```
 
-   is the census that corresponds to the `tree` given in the discusson of `simulate_wate_quality` above.  There is an area of interest eight cells in size, with five of type `"c:commercial"` and three of type `"a:deciduous_forest"`.
+   is the census that corresponds to the `tree` given in the discusson of `simulate_water_quality` above.  There is an area of interest eight cells in size, with five of type `"c:commercial"` and three of type `"a:deciduous_forest"`.
 
-   modifications are given as an array of dictionaries.  Each dictionary contains a either a `bmp` key or a `reclassification` key, indicating what type of modification has taken place.
+   Modifications are given as an array of dictionaries.  Each dictionary contains a `change` key whose value encodes the modification that has taken place.  In the example above, `"::no_till"` indicates that the no-till farming BMP has been applied, while `"a:rock:"` means that that particular area has been reclassified as being mostl rocks sitting on top of A-type soil.
 
-   2. The `cell_res` argument is as described previously.
+   2. The `fn` argument is as described previously, it is responsible for performing the simulation at each cell.
 
-   3. The `precolumbian` argument is as described previously.
+   3. The `cell_res` argument is as described previously.
 
-   4. The `fn` argument is as described previously.  If this argument is not supplied, then `simulate_cell_year` will be used to compute the runoff, evapotranspiration, and infiltration values.  A custom function can be supplied to do different types of calculations, such as calculations over shorter or longer time spans.  If a custom function is supplied, the `precolumbian` argument will be ignored.
-
-The output is dictionary with two keys, `modified` and `unmodified`.  These respectively contain modified and unmodified trees (as described in the discussion of `simulate_water_quality`) with runoff, evapotranspiration, infiltration, and pollutant loads included.
+The output is dictionary with two keys, `modified` and `unmodified`.  These respectively contain modified and unmodified trees (the trees are as described in the discussion of `simulate_water_quality`) with runoff, evapotranspiration, infiltration, and pollutant loads included.
 
 ## Usage Example
 
@@ -110,9 +119,9 @@ from __future__ import division
 
 import pprint
 
-from tr55.model import simulate_modifications
+from tr55.model import simulate_year
 
-cells = {
+census = {
     "cell_count": 147,
     "distribution": {
         "d:hi_residential": {"cell_count": 33},
@@ -121,7 +130,7 @@ cells = {
     },
     "modifications": [
         {
-            "bmp": "no_till",
+            "change": "::no_till",
             "cell_count": 30,
             "distribution": {
                 "d:hi_residential": {"cell_count": 10},
@@ -129,7 +138,7 @@ cells = {
             }
         },
         {
-            "reclassification": "d:rock",
+            "change": "d:rock:",
             "cell_count": 5,
             "distribution": {
                 "a:deciduous_forest": {"cell_count": 5}
@@ -138,7 +147,7 @@ cells = {
     ]
 }
 
-pprint.pprint(simulate_modifications(cells))
+pprint.pprint(simulate_year(census))
 ```
 is partially reproduced here:
 ```Python
@@ -176,7 +185,7 @@ is partially reproduced here:
                 'tss': 300.2237717935762}
 ```
 
-The output shown is another tree-like dictionary, akin to the one in the discussion of the first parameter of the `simulate_water_quality` function, except with additional keys and values attached to each  node in the tree.  The additional keys, `runoff`, `tss`, and so on, have associated values which are the water volumes and pollutant loads that have been calculated.  The volumes and loads at the leaves of the tree are those returned by the `fn` function (the fourth parameter of the `simulate_modifications` function), while those of internal nodes are the sums of the amounts found in their child nodes.
+The output shown is a tree-like dictionary, akin to the one in the discussion of the first parameter of the `simulate_water_quality` function, except with additional keys and values attached to each  node in the tree.  The additional keys, `runoff`, `tss`, and so on, have associated values which are the water volumes and pollutant loads that have been calculated.  The volumes and loads at the leaves of the tree are those returned by the `fn` function (the second parameter of the `simulate_modifications` function), while those of internal nodes are the sums of the amounts found in their child nodes.
 
 ## Testing
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -12,7 +12,8 @@ from math import sqrt
 
 from tr55.model import runoff_nrcs, \
     simulate_cell_day, simulate_cell_year, simulate_water_quality, \
-    create_unmodified_census, create_modified_census
+    create_unmodified_census, create_modified_census, \
+    simulate_day, simulate_year
 from tr55.tablelookup import lookup_ki
 
 # These data are taken directly from Table 2-1 of the revised (1986)
@@ -594,11 +595,709 @@ OUTPUT = [
     (7.8, 0.2, 0)
 ]
 
+CENSUS_1 = {
+    'cell_count': 147,
+    'distribution': {
+        'c:commercial': {
+            'cell_count': 42
+        },
+        'a:deciduous_forest': {
+            'cell_count': 72
+        },
+        'd:hi_residential': {
+            'cell_count': 33
+        }
+    },
+    'modifications': [
+        {
+            'change': '::no_till',
+            'cell_count': 30,
+            'distribution': {
+                'c:commercial': {
+                    'cell_count': 20
+                },
+                'd:hi_residential': {
+                    'cell_count': 10
+                }
+            }
+        },
+        {
+            'change': 'd:rock:',
+            'cell_count': 5,
+            'distribution': {
+                'a:deciduous_forest': {
+                    'cell_count': 5
+                }
+            },
+        }
+    ]
+}
+
+YEAR_OUTPUT_1 = {
+    'unmodified': {
+        'inf': 20.24558036990151,
+        'cell_count': 147,
+        'tp': 1.9158509765426026,
+        'tn': 11.858981443411944,
+        'runoff': 17.614211721110824,
+        'et': 15.167861632653095,
+        'distribution': {
+            'c:commercial': {
+                'cell_count': 42,
+                'tp': 1.2321451541995787,
+                'tn': 7.786472849455671,
+                'runoff': 36.375400229862464,
+                'et': 2.272860000000005,
+                'inf': 4.430079770137537,
+                'bod': 1061.0138827829708,
+                'tss': 216.39549270630107
+            },
+            'a:deciduous_forest': {
+                'cell_count': 72,
+                'tp': 0.0,
+                'tn': 0.0,
+                'runoff': 0.0,
+                'et': 26.51670000000007,
+                'inf': 34.91810000000001,
+                'bod': 0.0,
+                'tss': 0.0
+            },
+            'd:hi_residential': {
+                'cell_count': 33,
+                'tp': 0.6837058223430238,
+                'tn': 4.072508593956273,
+                'runoff': 32.167342828759615,
+                'et': 6.818579999999993,
+                'inf': 8.361629213022574,
+                'bod': 701.5416264041463,
+                'tss': 83.8282790872751
+            }
+        },
+        'bod': 1762.555509187117,
+        'tss': 300.2237717935762
+    },
+    'modified': {
+        'inf': 24.67740388835977,
+        'cell_count': 147,
+        'tp': 1.2402469548151882,
+        'tn': 7.649885146629041,
+        'runoff': 11.957947247429287,
+        'et': 20.450586122448982,
+        'distribution': {
+            'c:commercial': {
+                'inf': 16.198443763932524,
+                'cell_count': 42,
+                'tp': 0.7192244464514511,
+                'tn': 4.545098932436254,
+                'runoff': 21.23295052178176,
+                'et': 17.42526,
+                'distribution': {
+                    'c:commercial': {
+                        'cell_count': 22,
+                        'tp': 0.6454093664854939,
+                        'tn': 4.078628635429163,
+                        'runoff': 36.37540022986247,
+                        'et': 2.2728600000000068,
+                        'inf': 4.430079770137537,
+                        'bod': 555.7691766958419,
+                        'tss': 113.35001998901487
+                    },
+                    'c:commercial:no_till': {
+                        'cell_count': 20,
+                        'tp': 0.07381507996595724,
+                        'tn': 0.4664702970070909,
+                        'runoff': 4.576255842892978,
+                        'et': 34.0929,
+                        'inf': 29.143644157107012,
+                        'bod': 63.56298552624096,
+                        'tss': 12.96377341902124
+                    }
+                },
+                'bod': 619.3321622220828,
+                'tss': 126.3137934080361
+            },
+            'a:deciduous_forest': {
+                'inf': 34.53218880673186,
+                'cell_count': 72,
+                'tp': 0.0003225729096998572,
+                'tn': 0.0032257290969985716,
+                'runoff': 0.7999320266014792,
+                'et': 24.675262500000017,
+                'distribution': {
+                    'a:deciduous_forest': {
+                        'cell_count': 67,
+                        'tp': 0.0,
+                        'tn': 0.0,
+                        'runoff': 0.0,
+                        'et': 26.516700000000018,
+                        'inf': 34.9181,
+                        'bod': 0.0,
+                        'tss': 0.0
+                    },
+                    'd:rock:': {
+                        'cell_count': 5,
+                        'tp': 0.0003225729096998572,
+                        'tn': 0.0032257290969985716,
+                        'runoff': 11.519021183061302,
+                        'et': 0.0,
+                        'inf': 29.360978816938722,
+                        'bod': 42.579624080381144,
+                        'tss': 0.32257290969985714
+                    }
+                },
+                'bod': 42.579624080381144,
+                'tss': 0.32257290969985714
+            },
+            'd:hi_residential': {
+                'inf': 13.967458770273502,
+                'cell_count': 33,
+                'tp': 0.5206999354540374,
+                'tn': 3.101560485095788,
+                'runoff': 24.498158107332266,
+                'et': 15.08352545454543,
+                'distribution': {
+                    'd:hi_residential:no_till': {
+                        'cell_count': 10,
+                        'tp': 0.0441776956392026,
+                        'tn': 0.26314540445959805,
+                        'runoff': 6.859033248049366,
+                        'et': 34.0929,
+                        'inf': 26.860866751950642,
+                        'bod': 45.3301572645731,
+                        'tss': 5.416569639241362
+                    },
+                    'd:hi_residential': {
+                        'cell_count': 23,
+                        'tp': 0.47652223981483477,
+                        'tn': 2.83841508063619,
+                        'runoff': 32.167342828759615,
+                        'et': 6.818579999999968,
+                        'inf': 8.361629213022571,
+                        'bod': 488.9532547665262,
+                        'tss': 58.425770272949315
+                    }
+                },
+                'bod': 534.2834120310993,
+                'tss': 63.842339912190674
+            }
+        },
+        'bod': 1196.1951983335632,
+        'tss': 190.47870622992664
+    }
+}
+
+DAY_OUTPUT_1 = {
+    'unmodified': {
+        'inf': 1.4762466686413165,
+        'cell_count': 147,
+        'tp': 0.048497869127119175,
+        'tn': 0.3010544583784289,
+        'runoff': 0.4408688415627653,
+        'et': 0.08288448979591835,
+        'distribution': {
+            'c:commercial': {
+                'cell_count': 42,
+                'tp': 0.03354942097300307,
+                'tn': 0.21201370198217218,
+                'runoff': 0.9904463051399999,
+                'et': 0.01242,
+                'inf': 0.9971336948599999,
+                'bod': 28.889779171197087,
+                'tss': 5.892117058383664
+            },
+            'a:deciduous_forest': {
+                'cell_count': 72,
+                'tp': 0.0,
+                'tn': 0.0,
+                'runoff': 0.0,
+                'et': 0.14489999999999997,
+                'inf': 1.8550999999999997,
+                'bod': 0.0,
+                'tss': 0.0
+            },
+            'd:hi_residential': {
+                'cell_count': 33,
+                'tp': 0.014948448154116101,
+                'tn': 0.08904075639625678,
+                'runoff': 0.7033022695105,
+                'et': 0.037259999999999995,
+                'inf': 1.2594377304895001,
+                'bod': 15.33840767118,
+                'tss': 1.832809730200322
+            }
+        },
+        'bod': 44.228186842377085,
+        'tss': 7.724926788583986
+    },
+    'modified': {
+        'inf': 1.4443825689955982,
+        'cell_count': 147,
+        'tp': 0.04395677470812412,
+        'tn': 0.2721366245288691,
+        'runoff': 0.44386559426970806,
+        'et': 0.11175183673469387,
+        'distribution': {
+            'c:commercial': {
+                'inf': 1.077061870392374,
+                'cell_count': 42,
+                'tp': 0.02803732401552826,
+                'tn': 0.1771803114870189,
+                'runoff': 0.827718129607626,
+                'et': 0.09522,
+                'distribution': {
+                    'c:commercial': {
+                        'cell_count': 22,
+                        'tp': 0.017573506223953986,
+                        'tn': 0.11105479627637589,
+                        'runoff': 0.99044630514,
+                        'et': 0.012419999999999999,
+                        'inf': 0.99713369486,
+                        'bod': 15.132741470627044,
+                        'tss': 3.086347030581919
+                    },
+                    'c:commercial:no_till': {
+                        'cell_count': 20,
+                        'tp': 0.010463817791574277,
+                        'tn': 0.06612551521064301,
+                        'runoff': 0.6487171365220146,
+                        'et': 0.1863,
+                        'inf': 1.1649828634779853,
+                        'bod': 9.010509764966741,
+                        'tss': 1.8377079996452328
+                    }
+                },
+                'bod': 24.143251235593787,
+                'tss': 4.9240550302271515
+            },
+            'a:deciduous_forest': {
+                'inf': 1.7843552932085411,
+                'cell_count': 72,
+                'tp': 3.258553846153846e-05,
+                'tn': 0.0003258553846153846,
+                'runoff': 0.08080720679145877,
+                'et': 0.13483749999999997,
+                'distribution': {
+                    'a:deciduous_forest': {
+                        'cell_count': 67,
+                        'tp': 0.0,
+                        'tn': 0.0,
+                        'runoff': 0.0,
+                        'et': 0.14489999999999997,
+                        'inf': 1.8551,
+                        'bod': 0.0,
+                        'tss': 0.0
+                    },
+                    'd:rock:': {
+                        'cell_count': 5,
+                        'tp': 3.258553846153846e-05,
+                        'tn': 0.0003258553846153846,
+                        'runoff': 1.1636237777970062,
+                        'et': 0.0,
+                        'inf': 0.8363762222029937,
+                        'bod': 4.301291076923077,
+                        'tss': 0.032585538461538464
+                    }
+                },
+                'bod': 4.301291076923077,
+                'tss': 0.032585538461538464
+            },
+            'd:hi_residential': {
+                'inf': 1.1701229689350983,
+                'cell_count': 33,
+                'tp': 0.015886865154134316,
+                'tn': 0.09463045765723485,
+                'runoff': 0.7474533947012655,
+                'et': 0.08242363636363635,
+                'distribution': {
+                    'd:hi_residential:no_till': {
+                        'cell_count': 10,
+                        'tp': 0.005468249773992795,
+                        'tn': 0.03257174865378317,
+                        'runoff': 0.8490009826400262,
+                        'et': 0.1863,
+                        'inf': 0.9646990173599737,
+                        'bod': 5.610899768096954,
+                        'tss': 0.6704549722895514
+                    },
+                    'd:hi_residential': {
+                        'cell_count': 23,
+                        'tp': 0.010418615380141523,
+                        'tn': 0.06205870900345169,
+                        'runoff': 0.7033022695104999,
+                        'et': 0.037259999999999995,
+                        'inf': 1.2594377304895001,
+                        'bod': 10.690405346579997,
+                        'tss': 1.2774128422608306
+                    }
+                },
+                'bod': 16.30130511467695,
+                'tss': 1.947867814550382
+            }
+        },
+        'bod': 44.745847427193816,
+        'tss': 6.904508383239072
+    }
+}
+
+CENSUS_2 = {
+    'cell_count': 4,
+    'distribution': {
+        'd:hi_residential': {'cell_count': 1},
+        'c:commercial': {'cell_count': 1},
+        'a:deciduous_forest': {'cell_count': 1},
+        'b:pasture': {'cell_count': 1}
+    },
+    'modifications': [
+        {
+            'change': '::no_till',
+            'cell_count': 1,
+            'distribution': {
+                'b:pasture': {'cell_count': 1}
+            }
+        },
+        {
+            'change': '::cluster_housing',
+            'cell_count': 1,
+            'distribution': {
+                'd:hi_residential': {'cell_count': 1}
+            }
+        },
+        {
+            'change': '::rain_garden',
+            'cell_count': 1,
+            'distribution': {
+                'c:commercial': {'cell_count': 1}
+            }
+        }
+    ]
+}
+
+DAY_OUTPUT_2 = {
+    'unmodified': {
+        'inf': 1.4785857682509507,
+        'cell_count': 4,
+        'tp': 0.0013746500037446765,
+        'tn': 0.008688160939430185,
+        'runoff': 0.4417192317490494,
+        'et': 0.07969499999999999,
+        'distribution': {
+            'c:commercial': {
+                'cell_count': 1,
+                'tp': 0.0007987957374524541,
+                'tn': 0.005047945285289814,
+                'runoff': 0.99044630514,
+                'et': 0.012419999999999999,
+                'inf': 0.99713369486,
+                'bod': 0.687851885028502,
+                'tss': 0.14028850139008725
+            },
+            'a:deciduous_forest': {
+                'cell_count': 1,
+                'tp': 0.0,
+                'tn': 0.0,
+                'runoff': 0.0,
+                'et': 0.14489999999999997,
+                'inf': 1.8551,
+                'bod': 0.0,
+                'tss': 0.0
+            },
+            'b:pasture': {
+                'cell_count': 1,
+                'tp': 0.00012287098889476473,
+                'tn': 0.0009420109148598631,
+                'runoff': 0.0731283523456977,
+                'et': 0.12419999999999999,
+                'inf': 1.8026716476543023,
+                'bod': 0.04095699629825491,
+                'tss': 0.020478498149127455
+            },
+            'd:hi_residential': {
+                'cell_count': 1,
+                'tp': 0.0004529832773974576,
+                'tn': 0.002698204739280508,
+                'runoff': 0.7033022695105,
+                'et': 0.037259999999999995,
+                'inf': 1.2594377304895001,
+                'bod': 0.46480023245999996,
+                'tss': 0.05553968879394915
+            }
+        },
+        'bod': 1.1936091137867568,
+        'tss': 0.21630668833316385
+    },
+    'modified': {
+        'inf': 1.4978906201690463,
+        'cell_count': 4,
+        'tp': 0.0014947940356953506,
+        'tn': 0.010093182575177441,
+        'runoff': 0.3934343798309537,
+        'et': 0.108675,
+        'distribution': {
+            'c:commercial': {
+                'inf': 1.0641101843915999,
+                'cell_count': 1,
+                'tp': 0.0007414402317520271,
+                'tn': 0.004685490353432948,
+                'runoff': 0.9193298156084,
+                'et': 0.01656,
+                'distribution': {
+                    'c:commercial': {
+                        'cell_count': 0,
+                        'runoff': 0,
+                        'et': 0,
+                        'inf': 0
+                    },
+                    'c:commercial:rain_garden': {
+                        'cell_count': 1,
+                        'tp': 0.0007414402317520271,
+                        'tn': 0.004685490353432948,
+                        'runoff': 0.9193298156084,
+                        'et': 0.01656,
+                        'inf': 1.0641101843915999,
+                        'bod': 0.6384624217864677,
+                        'tss': 0.13021544070144975
+                    }
+                },
+                'bod': 0.6384624217864677,
+                'tss': 0.13021544070144975
+            },
+            'a:deciduous_forest': {
+                'cell_count': 1,
+                'tp': 0.0,
+                'tn': 0.0,
+                'runoff': 0.0,
+                'et': 0.14489999999999997,
+                'inf': 1.8551,
+                'bod': 0.0,
+                'tss': 0.0
+            },
+            'b:pasture': {
+                'inf': 1.4934093771285855,
+                'cell_count': 1,
+                'tp': 0.0005381555074547796,
+                'tn': 0.004125858890486643,
+                'runoff': 0.32029062287141463,
+                'et': 0.1863,
+                'distribution': {
+                    'b:pasture:no_till': {
+                        'cell_count': 1,
+                        'tp': 0.0005381555074547796,
+                        'tn': 0.004125858890486643,
+                        'runoff': 0.32029062287141463,
+                        'et': 0.1863,
+                        'inf': 1.4934093771285855,
+                        'bod': 0.1793851691515932,
+                        'tss': 0.0896925845757966
+                    },
+                    'b:pasture': {
+                        'cell_count': 0,
+                        'runoff': 0,
+                        'et': 0,
+                        'inf': 0
+                    }
+                },
+                'bod': 0.1793851691515932,
+                'tss': 0.0896925845757966
+            },
+            'd:hi_residential': {
+                'inf': 1.5789429191559998,
+                'cell_count': 1,
+                'tp': 0.000215198296488544,
+                'tn': 0.001281833331257849,
+                'runoff': 0.3341170808440001,
+                'et': 0.08693999999999999,
+                'distribution': {
+                    'd:hi_residential:cluster_housing': {
+                        'cell_count': 1,
+                        'tp': 0.000215198296488544,
+                        'tn': 0.001281833331257849,
+                        'runoff': 0.3341170808440001,
+                        'et': 0.08693999999999999,
+                        'inf': 1.5789429191559998,
+                        'bod': 0.220812165092593,
+                        'tss': 0.026385182439030177
+                    },
+                    'd:hi_residential': {
+                        'cell_count': 0,
+                        'runoff': 0,
+                        'et': 0,
+                        'inf': 0
+                    }
+                },
+                'bod': 0.220812165092593,
+                'tss': 0.026385182439030177
+            }
+        },
+        'bod': 1.0386597560306539,
+        'tss': 0.24629320771627652
+    }
+}
+
+YEAR_OUTPUT_2 = {
+    'unmodified': {
+        'inf': 20.72181910477488,
+        'cell_count': 4,
+        'tp': 0.050707291853983406,
+        'tn': 0.31380133435186236,
+        'runoff': 17.232718905670666,
+        'et': 14.58418499999997,
+        'distribution': {
+            'c:commercial': {
+                'cell_count': 1,
+                'tp': 0.029336789385704252,
+                'tn': 0.1853922107013255,
+                'runoff': 36.37540022986246,
+                'et': 2.272860000000009,
+                'inf': 4.430079770137537,
+                'bod': 25.262235304356444,
+                'tss': 5.15227363586431
+            },
+            'a:deciduous_forest': {
+                'cell_count': 1,
+                'tp': 0.0,
+                'tn': 0.0,
+                'runoff': 0.0,
+                'et': 26.516699999999968,
+                'inf': 34.918099999999995,
+                'bod': 0.0,
+                'tss': 0.0
+            },
+            'b:pasture': {
+                'cell_count': 1,
+                'tp': 0.0006521442154602603,
+                'tn': 0.004999772318528663,
+                'runoff': 0.38813256406059976,
+                'et': 22.72859999999992,
+                'inf': 35.177467435939406,
+                'bod': 0.21738140515342014,
+                'tss': 0.10869070257671007
+            },
+            'd:hi_residential': {
+                'cell_count': 1,
+                'tp': 0.020718358252818894,
+                'tn': 0.1234093513320082,
+                'runoff': 32.1673428287596,
+                'et': 6.818579999999982,
+                'inf': 8.361629213022574,
+                'bod': 21.258837163762,
+                'tss': 2.540250881432578
+            }
+        },
+        'bod': 46.738453873271865,
+        'tss': 7.801215219873598
+    },
+    'modified': {
+        'inf': 24.476938587987863,
+        'cell_count': 4,
+        'tp': 0.038879611034946346,
+        'tn': 0.24507035546075562,
+        'runoff': 12.571429731923587,
+        'et': 19.887524999999986,
+        'distribution': {
+            'c:commercial': {
+                'inf': 11.893415183645322,
+                'cell_count': 1,
+                'tp': 0.02310848228996424,
+                'tn': 0.14603277002685733,
+                'runoff': 28.652770449780387,
+                'et': 3.0304800000000034,
+                'distribution': {
+                    'c:commercial': {
+                        'cell_count': 0,
+                        'runoff': 0,
+                        'et': 0,
+                        'inf': 0
+                    },
+                    'c:commercial:rain_garden': {
+                        'cell_count': 1,
+                        'tp': 0.02310848228996424,
+                        'tn': 0.14603277002685733,
+                        'runoff': 28.652770449780387,
+                        'et': 3.0304800000000034,
+                        'inf': 11.893415183645322,
+                        'bod': 19.89897086080254,
+                        'tss': 4.05842720217497
+                    }
+                },
+                'bod': 19.89897086080254,
+                'tss': 4.05842720217497
+            },
+            'a:deciduous_forest': {
+                'cell_count': 1,
+                'tp': 0.0,
+                'tn': 0.0,
+                'runoff': 0.0,
+                'et': 26.516699999999968,
+                'inf': 34.918099999999995,
+                'bod': 0.0,
+                'tss': 0.0
+            },
+            'b:pasture': {
+                'inf': 31.946213918431017,
+                'cell_count': 1,
+                'tp': 0.0029801650911130345,
+                'tn': 0.022847932365199927,
+                'runoff': 1.7736860815689908,
+                'et': 34.092899999999936,
+                'distribution': {
+                    'b:pasture:no_till': {
+                        'cell_count': 1,
+                        'tp': 0.0029801650911130345,
+                        'tn': 0.022847932365199927,
+                        'runoff': 1.7736860815689908,
+                        'et': 34.092899999999936,
+                        'inf': 31.946213918431017,
+                        'bod': 0.9933883637043449,
+                        'tss': 0.49669418185217246
+                    },
+                    'b:pasture': {
+                        'cell_count': 0,
+                        'runoff': 0,
+                        'et': 0,
+                        'inf': 0
+                    }
+                },
+                'bod': 0.9933883637043449,
+                'tss': 0.49669418185217246
+            },
+            'd:hi_residential': {
+                'inf': 19.15002524987511,
+                'cell_count': 1,
+                'tp': 0.012790963653869069,
+                'tn': 0.07618965306869836,
+                'runoff': 19.859262396344974,
+                'et': 15.910020000000028,
+                'distribution': {
+                    'd:hi_residential:cluster_housing': {
+                        'cell_count': 1,
+                        'tp': 0.012790963653869069,
+                        'tn': 0.07618965306869836,
+                        'runoff': 19.859262396344974,
+                        'et': 15.910020000000028,
+                        'inf': 19.15002524987511,
+                        'bod': 13.124640966578697,
+                        'tss': 1.568283369735251
+                    },
+                    'd:hi_residential': {
+                        'cell_count': 0,
+                        'runoff': 0,
+                        'et': 0,
+                        'inf': 0
+                    }
+                },
+                'bod': 13.124640966578697,
+                'tss': 1.568283369735251
+            }
+        },
+        'bod': 34.01700019108558,
+        'tss': 6.123404753762394
+    }
+}
 
 def simulate(precip, tile_string):
-    soil_type, land_use = tile_string.split(':')
+    land_use = tile_string.split(':')[1]
     ki = lookup_ki(land_use)
-    return simulate_cell_day((precip, 0.207 * ki), tile_string, 1)
+    return simulate_cell_day(precip, 0.207 * ki, tile_string, 1)
 
 
 def average(l):
@@ -640,11 +1339,11 @@ class TestModel(unittest.TestCase):
         """
         # The number 0.04 is not very meaningful, this test just
         # attempts to give some idea about the mean error of the three
-        # quantities, relative to precipitation, compared to the
-        # sample output that was emailed to us.
+        # quantities -- relative to precipitation -- as compared to
+        # the sample output that was emailed to us.
         def similar(incoming, expected):
             precip, tile_string = incoming
-            results = simulate(precip, tile_string)
+            results = simulate(precip, tile_string + ':')
             results = (results['runoff-vol'],
                        results['et-vol'],
                        results['inf-vol'])
@@ -667,7 +1366,7 @@ class TestModel(unittest.TestCase):
         # 0.13 is not very meaningful, this test just attempts to put
         # a bound on the deviation between the current output and the
         # sample output that was mailed to us.
-        results = [simulate(precip, tile_string)['runoff-vol'] / precip
+        results = [simulate(precip, tile_string + ':')['runoff-vol'] / precip
                    for precip, tile_string in INPUT
                    if precip > 2 and tile_string != 'c:rock' and
                    tile_string != 'd:rock']
@@ -683,8 +1382,8 @@ class TestModel(unittest.TestCase):
         """
         Daily simulation.
         """
-        result1 = simulate_cell_day((42, 93), 'a:rock', 1)
-        result2 = simulate_cell_day((42, 93), 'a:rock', 2)
+        result1 = simulate_cell_day(42, 93, 'a:rock:', 1)
+        result2 = simulate_cell_day(42, 93, 'a:rock:', 2)
         self.assertEqual(result1['runoff-vol'] * 2, result2['runoff-vol'])
 
     def test_simulate_year(self):
@@ -716,7 +1415,7 @@ class TestModel(unittest.TestCase):
             },
             "modifications": [
                 {
-                    "bmp": "cluster_housing",
+                    "change": "::cluster_housing",
                     "cell_count": 1,
                     "distribution": {
                         "a:rock": {"cell_count": 1}
@@ -747,8 +1446,7 @@ class TestModel(unittest.TestCase):
 
     def test_create_modified_census_2(self):
         """
-        create_modified_census with a census tree with trivial
-        modifications.
+        create_modified_census with trivial modifications.
         """
         census = {
             "cell_count": 3,
@@ -765,8 +1463,7 @@ class TestModel(unittest.TestCase):
 
     def test_create_modified_census_3(self):
         """
-        create_modified_census with a census tree non-trivial
-        modifications.
+        create_modified_census with non-trivial modifications.
         """
         census1 = {
             "cell_count": 144,
@@ -776,7 +1473,7 @@ class TestModel(unittest.TestCase):
             },
             "modifications": [
                 {
-                    "bmp": "cluster_housing",
+                    "change": "::cluster_housing",
                     "cell_count": 34,
                     "distribution": {
                         "a:rock": {"cell_count": 34}
@@ -791,7 +1488,7 @@ class TestModel(unittest.TestCase):
                 "a:rock": {
                     "cell_count": 55,
                     "distribution": {
-                        "a:cluster_housing": {"cell_count": 34},
+                        "a:rock:cluster_housing": {"cell_count": 34},
                         "a:rock": {"cell_count": 21}
                     }
                 },
@@ -835,7 +1532,7 @@ class TestModel(unittest.TestCase):
             },
             "modifications": [
                 {
-                    "reclassification": "d:hi_residential",
+                    "change": "d:hi_residential:",
                     "cell_count": 1,
                     "distribution": {
                         "a:rock": {"cell_count": 1}
@@ -890,6 +1587,40 @@ class TestModel(unittest.TestCase):
         simulate_water_quality(census2, 93, fn)
         for key in set(census1.keys()) - set(['distribution']):
             self.assertEqual(census1[key], census2[key])
+
+    def test_year_1(self):
+        """
+        Test the simulate_year function.
+        """
+        actual = simulate_year(CENSUS_1)
+        expected = YEAR_OUTPUT_1
+        self.assertEqual(actual, expected)
+
+    def test_year_2(self):
+        """
+        Test the simulate_year function with lots of BMPs.
+        """
+        actual = simulate_year(CENSUS_2)
+        expected = YEAR_OUTPUT_2
+        self.assertEqual(actual, expected)
+
+    def test_day_1(self):
+        """
+        Test the simulate_day function.
+        """
+        precip = 2
+        actual = simulate_day(CENSUS_1, precip)
+        expected = DAY_OUTPUT_1
+        self.assertEqual(actual, expected)
+
+    def test_day_2(self):
+        """
+        Test the simulate_day function with lots of BMPs.
+        """
+        precip = 2
+        actual = simulate_day(CENSUS_2, precip)
+        expected = DAY_OUTPUT_2
+        self.assertEqual(actual, expected)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tr55/makeMiniAppTable.py
+++ b/tr55/makeMiniAppTable.py
@@ -7,8 +7,7 @@ from itertools import product
 import csv
 import sys
 
-from tr55.model import simulate_modifications, simulate_cell_day
-from tr55.tablelookup import lookup_ki
+from tr55.model import simulate_day
 
 if len(sys.argv) != 2:
     print 'Usage: python -m tr55.makeMiniAppTable csv_file_name'
@@ -44,9 +43,6 @@ with open(csv_file_name, 'wb') as csv_file:
 
     soil_types = ['a', 'b', 'c', 'd']
 
-    et_max = 0.207
-    pre_columbian = False
-
     # For each input value, compute the model outputs for a
     # single day and tile.
     for precip, land_use, soil_type in product(precips,
@@ -59,12 +55,7 @@ with open(csv_file_name, 'wb') as csv_file:
             }
         }
 
-        def fn(cell, cell_count):
-            (soil_type, land_use) = cell.lower().split(':')
-            et = et_max * lookup_ki(land_use)
-            return simulate_cell_day((precip, et), cell, cell_count)
-
-        model_out = (simulate_modifications(cells, fn=fn)
+        model_out = (simulate_day(cells, precip)
                      ['unmodified']['distribution'].values()[0])
         writer.writerow((precip, land_use,
                          soil_type, model_out['et'],

--- a/tr55/tablelookup.py
+++ b/tr55/tablelookup.py
@@ -27,7 +27,7 @@ def lookup_pet(day, land_use):
     Lookup/compute evapotranspiration from the tables.
     """
     (precip, et_max) = SAMPLE_YEAR[day]
-    ki = LAND_USE_VALUES[land_use]['ki']
+    ki = lookup_ki(land_use)
     return (precip, et_max * ki)
 
 


### PR DESCRIPTION
The modification types "bmp" and "reclassification" have been unified into a single type: "change".

For a modification, the word "change" is given as a key with an associated value which is a string of the form "soil:landuse:bmp".  Any missing items (for example, soil and landuse when a BMP is being represented) can simply be left blank (for example, "::green_roof").

This is in service of WikiWatershed/model-my-watershed#585