### PR TITLE
Let simulate_day do Pre-Columbian calculation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,6 @@ The `simulate_cell_year` function simulates the events of an entire year for one
 
    2. `cell_count` is the number of occurrences of that type of cell in the area of interest.
 
-   3. `precolumbian` is a boolean which determines whether to simulate the cell type as-shown or under Pre-Columbian circumstances.  When a Pre-Columbian simulation is done, all land uses other than *water* and *wetland* are treated as *mixed forest*.
-
 The output of this function is a dictionary with three keys: `runoff-vol`, `et-vol`, and `inf-vol`.  These are the volumes of runoff, evapotranspiration, and infiltration, respectively, in units of inch-cells.  The algorithm used to calculate these quantities is close to TR-55, the algorithm found in [the USDA's Technical Release 55, revised 1986](http://www.cpesc.org/reference/tr55.pdf), but with a few differences.  The main difference is the use of *Pitt Small Storm Hydrology Model* for low levels of precipitation when the land use is a built-type.
 
 ### `simulate_water_quality`
@@ -62,9 +60,11 @@ The `simulate_water_quality` function does a water quality calculation over an e
 
    The single cells of *deciduous forest*, *no-till*, and the *rock* are all underneath a node of three cells of type *deciduous forest*.  That indicates a land use modification has taken place: in this case, two of three original cells of *deciduous forest* have undergone modifications.
 
-   2. The `cell_res` parameter gives the resolution (size) of each cell.  It is used for converting runoff, evapotranspiration, and infiltration amounts from inches to volumes.
+   2. `fn` is the function that is used to perform the runoff, evapotranspiration, and infiltration calculation.  It is similar to `simulate_cell_year`, except it only takes `cell` and `cell_count` arguments.
 
-   3. `fn` is the function that is used to perform the runoff, evapotranspiration, and infiltration calculation.  It is similar to `simulate_cell_year`, except it only takes `cell` and `cell_count` arguments.
+   3. The `cell_res` parameter gives the resolution (size) of each cell.  It is used for converting runoff, evapotranspiration, and infiltration amounts from inches to volumes.
+
+   4. `precolumbian` is a boolean which determines whether to simulate the cell type as-shown or under Pre-Columbian circumstances.  When a Pre-Columbian simulation is done, all land uses other than *water* and *wetland* are treated as *mixed forest*.
 
 ### `simulate_modifications`
 
@@ -102,9 +102,11 @@ This function is used to simulate the effects of land use modifications.  The ar
 
    Modifications are given as an array of dictionaries.  Each dictionary contains a `change` key whose value encodes the modification that has taken place.  In the example above, `"::no_till"` indicates that the no-till farming BMP has been applied, while `"a:rock:"` means that that particular area has been reclassified as being mostl rocks sitting on top of A-type soil.
 
-   2. The `fn` argument is as described previously, it is responsible for performing the simulation at each cell.
+   2. The `cell_res` argument is as described previously.
 
-   3. The `cell_res` argument is as described previously.
+   3. The `fn` argument is as described previously, it is responsible for performing the simulation at each cell.
+
+   4. `precolumbian` is a boolean which determines whether to simulate the cell type as-shown or under Pre-Columbian circumstances.  When a Pre-Columbian simulation is done, all land uses other than *water* and *wetland* are treated as *mixed forest*.
 
 The output is dictionary with two keys, `modified` and `unmodified`.  These respectively contain modified and unmodified trees (the trees are as described in the discussion of `simulate_water_quality`) with runoff, evapotranspiration, infiltration, and pollutant loads included.
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1386,22 +1386,14 @@ class TestModel(unittest.TestCase):
         result2 = simulate_cell_day(42, 93, 'a:rock:', 2)
         self.assertEqual(result1['runoff-vol'] * 2, result2['runoff-vol'])
 
-    def test_simulate_year(self):
+    def test_simulate_cell_year(self):
         """
         Yearly simulation.
         """
-        result1 = simulate_cell_year('a:hi_residential', 42, False)
-        result2 = simulate_cell_year('a:mixed_forest', 42, False)
+        result1 = simulate_cell_year('a:hi_residential:', 42)
+        result2 = simulate_cell_year('a:mixed_forest:', 42)
         self.assertNotEqual(result1, result2)
         self.assertGreater(result1['runoff-vol'], result2['runoff-vol'])
-
-    def test_simulate_year_precolumbian(self):
-        """
-        Yearly simulation in Pre-Columbian times.
-        """
-        result1 = simulate_cell_year('a:hi_residential', 42, True)
-        result2 = simulate_cell_year('a:mixed_forest', 42, True)
-        self.assertEqual(result1, result2)
 
     def test_create_unmodified_census(self):
         """
@@ -1512,7 +1504,7 @@ class TestModel(unittest.TestCase):
         }
 
         def fn(cell, cell_count):
-            return simulate_cell_year(cell, cell_count, False)
+            return simulate_cell_year(cell, cell_count)
 
         simulate_water_quality(census, 93, fn)
         left = census['distribution']['a:rock']
@@ -1551,7 +1543,7 @@ class TestModel(unittest.TestCase):
         }
 
         def fn(cell, cell_count):
-            return simulate_cell_year(cell, cell_count, False)
+            return simulate_cell_year(cell, cell_count)
 
         simulate_water_quality(census1, 93, fn)
         simulate_water_quality(census2, 93, fn)
@@ -1563,30 +1555,47 @@ class TestModel(unittest.TestCase):
         Test the water quality simulation in Pre-Columbian times.
         """
         census1 = {
-            "cell_count": 3,
+            "cell_count": 8,
             "distribution": {
-                "a:rock": {"cell_count": 1},
-                "b:herbaceous_wetland": {"cell_count": 1},
-                "a:water": {"cell_count": 1}
+                "a:hi_residential": {"cell_count": 1},
+                "b:no_till": {"cell_count": 1},
+                "c:pasture": {"cell_count": 1},
+                "d:row_crop": {"cell_count": 1},
+                "a:water": {"cell_count": 1},
+                "b:chaparral": {"cell_count": 1},
+                "c:desert": {"cell_count": 1},
+                "d:tall_grass_prairie": {"cell_count": 1}
             }
         }
 
         census2 = {
-            "cell_count": 3,
+            "cell_count": 8,
             "distribution": {
                 "a:mixed_forest": {"cell_count": 1},
-                "b:herbaceous_wetland": {"cell_count": 1},
-                "a:water": {"cell_count": 1}
+                "b:mixed_forest": {"cell_count": 1},
+                "c:mixed_forest": {"cell_count": 1},
+                "d:mixed_forest": {"cell_count": 1},
+                "a:water": {"cell_count": 1},
+                "b:chaparral": {"cell_count": 1},
+                "c:desert": {"cell_count": 1},
+                "d:tall_grass_prairie": {"cell_count": 1}
             }
         }
 
-        def fn(cell, cell_count):
-            return simulate_cell_year(cell, cell_count, True)
+        census3 = census2.copy()
 
-        simulate_water_quality(census1, 93, fn)
-        simulate_water_quality(census2, 93, fn)
+        def fn(cell, cell_count):
+            return simulate_cell_year(cell, cell_count)
+
+        simulate_water_quality(census1, 93, fn, precolumbian=True)
+        simulate_water_quality(census2, 93, fn, precolumbian=True)
+        simulate_water_quality(census3, 93, fn, precolumbian=False)
+
         for key in set(census1.keys()) - set(['distribution']):
-            self.assertEqual(census1[key], census2[key])
+            self.assertAlmostEqual(census1[key], census2[key])
+
+        for key in set(census1.keys()) - set(['distribution']):
+            self.assertAlmostEqual(census2[key], census3[key])
 
     def test_year_1(self):
         """

--- a/tr55/tablelookup.py
+++ b/tr55/tablelookup.py
@@ -8,7 +8,7 @@ Various routines to do table lookups.
 """
 
 from tr55.tables import SAMPLE_YEAR, BMPS, BUILT_TYPES, LAND_USE_VALUES, \
-    PRE_COLUMBIAN_LAND_USES, POLLUTANTS, POLLUTION_LOADS
+    NON_NATURAL, POLLUTANTS, POLLUTION_LOADS
 
 
 def lookup_ki(land_use):
@@ -75,7 +75,7 @@ def make_precolumbian(land_use):
     """
     Project the given land use to a Pre-Columbian one.
     """
-    if land_use not in PRE_COLUMBIAN_LAND_USES:
+    if land_use in NON_NATURAL:
         return 'mixed_forest'
     else:
         return land_use

--- a/tr55/tables.py
+++ b/tr55/tables.py
@@ -428,11 +428,8 @@ BUILT_TYPES = set(['li_residential', 'hi_residential', 'cluster_housing',
                    'commercial', 'industrial', 'transportation',
                    'urban_grass'])
 
-PRE_COLUMBIAN_LAND_USES = set([
-    'water',
-    'woody_wetland',
-    'herbaceous_wetland'
-])
+NON_NATURAL = set(['pasture', 'hay', 'row_crop', 'green_roof']) \
+    | set(['no_till']) | BMPS | BUILT_TYPES
 
 # The set of pollutants that we are concerned with.
 POLLUTANTS = set(['tn', 'tp', 'bod', 'tss'])


### PR DESCRIPTION
The simulate_year function already had this ability.  The definition of "Pre-Columbian" has also been changed: previously, anything other than "water", "herbaceous wetland", or "woody wetland" would be transformed into "mixed forest".  Now, only built-types are transformed into "mixed forest".

My interpretation of earlier instructions was that anything other than the three types mentioned was to be turned into *mixed forest*.  However, the statement of card #36 lists a number of built-types and says that all of them should be transformed into *mixed forest* -- I took the liberty of generalizing this to all built types.

Connects #36