### PR TITLE
Modified census bug.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ This function takes three arguments: a census of the area of interest, an option
 
 ### `simulate_day`
 
-This function takes three arguments: a census of the area of interest (see the description given below in the discussion of `simulate_modifications`), an amount of precipitation in inches, and an optional cell resolution (the size of a cell in square meters).
+This function takes four arguments: a census of the area of interest (see the description given below in the discussion of `simulate_modifications`), an amount of precipitation in inches, an optional cell resolution (the size of a cell in square meters), and an optional boolean  to control whether or not a Pre-Columbian simulation is done.
 
 ## Functions for Custom Scenarios
 
 ### `simulate_cell_year`
 
-The `simulate_cell_year` function simulates the events of an entire year for one specific type of cell.  It takes three arguments:
+The `simulate_cell_year` function simulates the events of an entire year for one specific type of cell.  It takes two arguments:
 
    1. `cell` is a string consisting of a soil type and land use pair separated by a colon, for example `"a:rock"`.
 
@@ -60,11 +60,11 @@ The `simulate_water_quality` function does a water quality calculation over an e
 
    The single cells of *deciduous forest*, *no-till*, and the *rock* are all underneath a node of three cells of type *deciduous forest*.  That indicates a land use modification has taken place: in this case, two of three original cells of *deciduous forest* have undergone modifications.
 
-   2. `fn` is the function that is used to perform the runoff, evapotranspiration, and infiltration calculation.  It is similar to `simulate_cell_year`, except it only takes `cell` and `cell_count` arguments.
+   2. The `cell_res` parameter gives the resolution (size) of each cell.  It is used for converting runoff, evapotranspiration, and infiltration amounts from inches to volumes.
 
-   3. The `cell_res` parameter gives the resolution (size) of each cell.  It is used for converting runoff, evapotranspiration, and infiltration amounts from inches to volumes.
+   3. `fn` is the function that is used to perform the runoff, evapotranspiration, and infiltration calculation.  It is similar to `simulate_cell_year`, except it only takes `cell` and `cell_count` arguments.
 
-   4. `precolumbian` is a boolean which determines whether to simulate the cell type as-shown or under Pre-Columbian circumstances.  When a Pre-Columbian simulation is done, all land uses other than *water* and *wetland* are treated as *mixed forest*.
+   4. `precolumbian` is an optional boolean which determines whether to simulate the cell type as-shown or under Pre-Columbian circumstances.  When a Pre-Columbian simulation is done, all land uses other than *water* and *wetland* are treated as *mixed forest*.
 
 ### `simulate_modifications`
 
@@ -102,11 +102,11 @@ This function is used to simulate the effects of land use modifications.  The ar
 
    Modifications are given as an array of dictionaries.  Each dictionary contains a `change` key whose value encodes the modification that has taken place.  In the example above, `"::no_till"` indicates that the no-till farming BMP has been applied, while `"a:rock:"` means that that particular area has been reclassified as being mostl rocks sitting on top of A-type soil.
 
-   2. The `cell_res` argument is as described previously.
+   2. The `fn` argument is as described previously, it is responsible for performing the simulation at each cell.
 
-   3. The `fn` argument is as described previously, it is responsible for performing the simulation at each cell.
+   3. The `cell_res` argument is as described previously.
 
-   4. `precolumbian` is a boolean which determines whether to simulate the cell type as-shown or under Pre-Columbian circumstances.  When a Pre-Columbian simulation is done, all land uses other than *water* and *wetland* are treated as *mixed forest*.
+   4. `precolumbian` is an optional boolean which determines whether to simulate the cell type as-shown or under Pre-Columbian circumstances.  When a Pre-Columbian simulation is done, all land uses other than *water* and *wetland* are treated as *mixed forest*.
 
 The output is dictionary with two keys, `modified` and `unmodified`.  These respectively contain modified and unmodified trees (the trees are as described in the discussion of `simulate_water_quality`) with runoff, evapotranspiration, infiltration, and pollutant loads included.
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1294,6 +1294,7 @@ YEAR_OUTPUT_2 = {
     }
 }
 
+
 def simulate(precip, tile_string):
     land_use = tile_string.split(':')[1]
     ki = lookup_ki(land_use)
@@ -1490,6 +1491,58 @@ class TestModel(unittest.TestCase):
 
         result = create_modified_census(census1)
         self.assertEqual(census2, result)
+
+    def test_create_modified_census_4(self):
+        """
+        create_modified_census with different types of changes.
+        """
+        census = {
+            "distribution": {
+                "a:li_residential": {
+                    "cell_count": 3
+                }
+            },
+            "cell_count": 3,
+            "modifications": [
+                {
+                    "distribution": {
+                        "a:li_residential": {
+                            "cell_count": 1
+                        }
+                    },
+                    "cell_count": 1,
+                    "change": ":deciduous_forest:cluster_housing"
+                },
+                {
+                    "distribution": {
+                        "a:li_residential": {
+                            "cell_count": 1
+                        }
+                    },
+                    "cell_count": 1,
+                    "change": ":deciduous_forest:"
+                },
+                {
+                    "distribution": {
+                        "a:li_residential": {
+                            "cell_count": 1
+                        }
+                    },
+                    "cell_count": 1,
+                    "change": "::cluster_housing"
+                },
+            ]
+        }
+
+        expected = set([
+            'a:deciduous_forest:',
+            'a:li_residential',
+            'a:deciduous_forest:cluster_housing',
+            'a:li_residential:cluster_housing'])
+        modified = create_modified_census(census)
+        distrib = modified['distribution']['a:li_residential']['distribution']
+        actual = set(distrib.keys())
+        self.assertEqual(actual, expected)
 
     def test_simulate_water_quality_1(self):
         """

--- a/tr55/model.py
+++ b/tr55/model.py
@@ -241,15 +241,17 @@ def create_modified_census(census):
                 else:
                     raise Exception('Unknown modification type.')
 
-                parent['distribution'] = {
-                    cell: {"cell_count": n - m},
-                    changed_cell: {"cell_count": m}
-                }
+                if 'distribution' not in parent:
+                    parent['distribution'] = {cell: {'cell_count': n}}
+
+                parent['distribution'][cell]['cell_count'] -= m
+                parent['distribution'][changed_cell] = {'cell_count': m}
 
     return mod
 
 
-def simulate_water_quality(tree, cell_res, fn, current_cell=None, precolumbian=False):
+def simulate_water_quality(tree, cell_res, fn,
+                           current_cell=None, precolumbian=False):
     """
     Perform a water quality simulation by doing simulations on each of
     the cell types (leaves), then adding them together by summing the
@@ -275,7 +277,8 @@ def simulate_water_quality(tree, cell_res, fn, current_cell=None, precolumbian=F
         if n != 0:
             tally = {}
             for cell, subtree in tree['distribution'].items():
-                simulate_water_quality(subtree, cell_res, fn, cell, precolumbian)
+                simulate_water_quality(subtree, cell_res, fn,
+                                       cell, precolumbian)
                 subtree_ex_dist = subtree.copy()
                 subtree_ex_dist.pop('distribution', None)
                 tally = dict_plus(tally, subtree_ex_dist)

--- a/tr55/water_quality.py
+++ b/tr55/water_quality.py
@@ -16,7 +16,7 @@ def get_volume_of_runoff(runoff, cell_count, cell_resolution):
 
         cell_count (integer): The number of cells included in the area
 
-        cell_resolution (integer): The size in meters that a cell represents
+        cell_resolution (number): The size in square meters that a cell represents
 
     Returns:
         The volume of runoff liters in of the total area of interest
@@ -29,7 +29,7 @@ def get_volume_of_runoff(runoff, cell_count, cell_resolution):
 
     runoff_m = runoff * inch_to_meter
     meter_cells = runoff_m * cell_count
-    volume_cubic_meters = meter_cells * cell_resolution  # XXX
+    volume_cubic_meters = meter_cells * cell_resolution
 
     liters = volume_cubic_meters * 1000
 


### PR DESCRIPTION
This fixes a bug in the computation of modified censuses.  A new test has also been added to exercise this fix.

Connects WikiWatershed/model-my-watershed#701

The bug in https://github.com/WikiWatershed/model-my-watershed/pull/713 that I thought was in the MMW backend python code that I had written turned out to be in the TR-55 implementation.

**To test**
   * The symptom of the bug appears in MMW when you:
       * Draw a large area of forest over a paved area (like in the middle of Philadelphia)
       * The runoff will go way down, as it should
       * Draw a bmp that cuts the forest into two pieces
       * The runoff will spring back up to its original value (because the modified census was not being correctly created)
   * You see examples of the bug by running the census given in the new test `test_create_modified_census_4` through the code before this change.  You will see that the modified census is incorrect.  Doing so after applying the change gives a correct modified census.