### PR TITLE
Feature/lol/align nlcd strings2

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This function takes four arguments: a census of the area of interest (see the de
 
 The `simulate_cell_year` function simulates the events of an entire year for one specific type of cell.  It takes two arguments:
 
-   1. `cell` is a string consisting of a soil type and land use pair separated by a colon, for example `"a:rock"`.
+   1. `cell` is a string consisting of a soil type and land use pair separated by a colon, for example `"a:barren_land"`.
 
    2. `cell_count` is the number of occurrences of that type of cell in the area of interest.
 
@@ -43,28 +43,28 @@ The `simulate_water_quality` function does a water quality calculation over an e
    {
        "cell_count": 8,
        "distribution": {
-           "c:commercial": {"cell_count": 5},
+           "c:developed_high": {"cell_count": 5},
            "a:deciduous_forest": {
                "cell_count": 3
                "distribution": {
                    "a:deciduous_forest": {"cell_count": 1},
                    "a:no_till": {"cell_count": 1},
-                   "d:rock": {"cell_count", 1}
+                   "d:barren_land": {"cell_count", 1}
                }
            }
        }
    }
    ```
 
-   represents an area of interest that is eight cells in size, with five of those cells of type `"c:commercial"` (*commercial* land use on top of type *C* soil), and one cell each of *deciduous forest*, *no-till farming*, and *rock*.
+   represents an area of interest that is eight cells in size, with five of those cells of type `"c:developed_high"` (*Developed High Intensity* land use on top of type *C* soil), and one cell each of *deciduous forest*, *no-till farming*, and *barren land*.
 
-   The single cells of *deciduous forest*, *no-till*, and the *rock* are all underneath a node of three cells of type *deciduous forest*.  That indicates a land use modification has taken place: in this case, two of three original cells of *deciduous forest* have undergone modifications.
+   The single cells of *deciduous forest*, *no-till*, and the *barren land* are all underneath a node of three cells of type *deciduous forest*.  That indicates a land use modification has taken place: in this case, two of three original cells of *deciduous forest* have undergone modifications.
 
    2. The `cell_res` parameter gives the resolution (size) of each cell.  It is used for converting runoff, evapotranspiration, and infiltration amounts from inches to volumes.
 
    3. `fn` is the function that is used to perform the runoff, evapotranspiration, and infiltration calculation.  It is similar to `simulate_cell_year`, except it only takes `cell` and `cell_count` arguments.
 
-   4. `precolumbian` is an optional boolean which determines whether to simulate the cell type as-shown or under Pre-Columbian circumstances.  When a Pre-Columbian simulation is done, all land uses other than *water* and *wetland* are treated as *mixed forest*.
+   4. `precolumbian` is an optional boolean which determines whether to simulate the cell type as-shown or under Pre-Columbian circumstances.  When a Pre-Columbian simulation is done, all developed land (NLCD 21-24) uses are treated as *mixed forest*.
 
 ### `simulate_modifications`
 
@@ -76,7 +76,7 @@ This function is used to simulate the effects of land use modifications.  The ar
    {
        "cell_count": 8,
        "distribution": {
-           "c:commercial": {"cell_count": 5},
+           "c:developed_high": {"cell_count": 5},
            "a:deciduous_forest": {"cell_count": 3}
        },
        "modifications": [
@@ -88,7 +88,7 @@ This function is used to simulate the effects of land use modifications.  The ar
                }
            },
            {
-               "change": "d:rock:",
+               "change": "d:barren_land:",
                "cell_count": 1,
                "distribution": {
                    "a:deciduous_forest": {"cell_count": 1}
@@ -98,9 +98,9 @@ This function is used to simulate the effects of land use modifications.  The ar
    }
    ```
 
-   is the census that corresponds to the `tree` given in the discusson of `simulate_water_quality` above.  There is an area of interest eight cells in size, with five of type `"c:commercial"` and three of type `"a:deciduous_forest"`.
+   is the census that corresponds to the `tree` given in the discussion of `simulate_water_quality` above.  There is an area of interest eight cells in size, with five of type `"c:developed_high"` and three of type `"a:deciduous_forest"`.
 
-   Modifications are given as an array of dictionaries.  Each dictionary contains a `change` key whose value encodes the modification that has taken place.  In the example above, `"::no_till"` indicates that the no-till farming BMP has been applied, while `"a:rock:"` means that that particular area has been reclassified as being mostl rocks sitting on top of A-type soil.
+   Modifications are given as an array of dictionaries.  Each dictionary contains a `change` key whose value encodes the modification that has taken place.  In the example above, `"::no_till"` indicates that the no-till farming BMP has been applied, while `"a:barren_land:"` means that that particular area has been reclassified as being most barren_land sitting on top of A-type soil.
 
    2. The `fn` argument is as described previously, it is responsible for performing the simulation at each cell.
 
@@ -109,6 +109,28 @@ This function is used to simulate the effects of land use modifications.  The ar
    4. `precolumbian` is an optional boolean which determines whether to simulate the cell type as-shown or under Pre-Columbian circumstances.  When a Pre-Columbian simulation is done, all land uses other than *water* and *wetland* are treated as *mixed forest*.
 
 The output is dictionary with two keys, `modified` and `unmodified`.  These respectively contain modified and unmodified trees (the trees are as described in the discussion of `simulate_water_quality`) with runoff, evapotranspiration, infiltration, and pollutant loads included.
+
+
+## Allowed Types
+
+The following land use values are implemented and correspond to the keys listed:
+
+ - 'open_water' - NLCD Type 11, Open Water
+ - 'developed_open' - NLCD Type 21, Developed, Open Space
+ - 'developed_low'- NLCD Type 22, Developed, Low Intensity
+ - 'developed_med' - NLCD Type 23, Developed, Medium Intensity
+ - 'developed_high' - NLCD Type 24, Developed, High Intensity
+ - 'barren_land' - NLCD Type 31, Barren Land (Rock/Sand/Clay)
+ - 'deciduous_forest' - NLCD Type 41, Deciduous Forest
+ - 'evergreen_forest' - NLCD Type 42, Evergreen Forest
+ - 'mixed_forest' - NLCD Type 43, Mixed Forest
+ - 'shrub' - NLCD Type 52, Shrub/Scrub
+ - 'grassland' - NLCD Type 71, Grassland/Herbaceous
+ - 'pasture' - NLCD Type 81, Pasture/Hay
+ - 'cultivated_crops' - NLCD Type 82, Cultivated Crops
+ - 'woody_wetlands' - NLCD Type 90, Woody Wetlands
+ - 'herbaceous_wetlands' - NLCD Type 95, Emergent Herbaceous Wetlands
+
 
 ## Usage Example
 
@@ -126,8 +148,8 @@ from tr55.model import simulate_year
 census = {
     "cell_count": 147,
     "distribution": {
-        "d:hi_residential": {"cell_count": 33},
-        "c:commercial": {"cell_count": 42},
+        "d:developed_med": {"cell_count": 33},
+        "c:developed_high": {"cell_count": 42},
         "a:deciduous_forest": {"cell_count": 72}
     },
     "modifications": [
@@ -135,12 +157,12 @@ census = {
             "change": "::no_till",
             "cell_count": 30,
             "distribution": {
-                "d:hi_residential": {"cell_count": 10},
-                "c:commercial": {"cell_count": 20}
+                "d:developed_med": {"cell_count": 10},
+                "c:developed_high": {"cell_count": 20}
             }
         },
         {
-            "change": "d:rock:",
+            "change": "d:barren_land:",
             "cell_count": 5,
             "distribution": {
                 "a:deciduous_forest": {"cell_count": 5}
@@ -163,7 +185,7 @@ is partially reproduced here:
                                                         'tn': 0.0,
                                                         'tp': 0.0,
                                                         'tss': 0.0},
-                                 'c:commercial': {'bod': 1061.0138827829708,
+                                 'c:developed_high': {'bod': 1061.0138827829708,
                                                   'cell_count': 42,
                                                   'et': 2.272860000000005,
                                                   'inf': 4.430079770137537,
@@ -171,7 +193,7 @@ is partially reproduced here:
                                                   'tn': 7.786472849455671,
                                                   'tp': 1.2321451541995787,
                                                   'tss': 216.39549270630107},
-                                 'd:hi_residential': {'bod': 701.5416264041463,
+                                 'd:developed_med': {'bod': 701.5416264041463,
                                                       'cell_count': 33,
                                                       'et': 6.818579999999993,
                                                       'inf': 8.361629213022574,

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -27,39 +27,41 @@ CN70 = [0.000, 0.030, 0.060, 0.110, 0.170, 0.240, 0.460, 0.710, 1.010, 1.330, 1.
 CN80 = [0.080, 0.150, 0.240, 0.340, 0.440, 0.560, 0.890, 1.250, 1.640, 2.040, 2.460, 2.890, 3.780, 4.690, 5.630, 6.570, 7.520, 8.480, 9.450, 10.42, 11.39, 12.37]  # noqa
 CN90 = [0.320, 0.460, 0.610, 0.760, 0.930, 1.090, 1.530, 1.980, 2.450, 2.920, 3.400, 3.880, 4.850, 5.820, 6.810, 7.790, 8.780, 9.770, 10.76, 11.76, 12.75, 13.74]  # noqa
 
-# INPUT and OUTPUT are data that were emailed to Azavea in a
-# spreadsheet for testing the TR-55 model implementation.
+# INPUT and OUTPUT are data that were emailed to Azavea in a spreadsheet for
+# testing the TR-55 model implementation. The types were converted to NLCD
+# strings based on the NLCD type number used by tables.py to calculate
+# model results.
 INPUT = [
-    (0.5, 'a:water'),
-    (1, 'a:water'),
-    (2, 'a:water'),
-    (3.2, 'a:water'),
-    (8, 'a:water'),
-    (0.5, 'a:rock'),
-    (1, 'a:rock'),
-    (2, 'a:rock'),
-    (3.2, 'a:rock'),
-    (8, 'a:rock'),
-    (0.5, 'a:urban_grass'),
-    (1, 'a:urban_grass'),
-    (2, 'a:urban_grass'),
-    (3.2, 'a:urban_grass'),
-    (8, 'a:urban_grass'),
-    (0.5, 'a:li_residential'),
-    (1, 'a:li_residential'),
-    (2, 'a:li_residential'),
-    (3.2, 'a:li_residential'),
-    (8, 'a:li_residential'),
-    (0.5, 'a:hi_residential'),
-    (1, 'a:hi_residential'),
-    (2, 'a:hi_residential'),
-    (3.2, 'a:hi_residential'),
-    (8, 'a:hi_residential'),
-    (0.5, 'a:commercial'),
-    (1, 'a:commercial'),
-    (2, 'a:commercial'),
-    (3.2, 'a:commercial'),
-    (8, 'a:commercial'),
+    (0.5, 'a:open_water'),
+    (1, 'a:open_water'),
+    (2, 'a:open_water'),
+    (3.2, 'a:open_water'),
+    (8, 'a:open_water'),
+    (0.5, 'a:barren_land'),
+    (1, 'a:barren_land'),
+    (2, 'a:barren_land'),
+    (3.2, 'a:barren_land'),
+    (8, 'a:barren_land'),
+    (0.5, 'a:developed_open'),
+    (1, 'a:developed_open'),
+    (2, 'a:developed_open'),
+    (3.2, 'a:developed_open'),
+    (8, 'a:developed_open'),
+    (0.5, 'a:developed_low'),
+    (1, 'a:developed_low'),
+    (2, 'a:developed_low'),
+    (3.2, 'a:developed_low'),
+    (8, 'a:developed_low'),
+    (0.5, 'a:developed_med'),
+    (1, 'a:developed_med'),
+    (2, 'a:developed_med'),
+    (3.2, 'a:developed_med'),
+    (8, 'a:developed_med'),
+    (0.5, 'a:developed_high'),
+    (1, 'a:developed_high'),
+    (2, 'a:developed_high'),
+    (3.2, 'a:developed_high'),
+    (8, 'a:developed_high'),
     (0.5, 'a:deciduous_forest'),
     (0.5, 'a:evergreen_forest'),
     (0.5, 'a:mixed_forest'),
@@ -85,51 +87,51 @@ INPUT = [
     (2, 'a:pasture'),
     (3.2, 'a:pasture'),
     (8, 'a:pasture'),
-    (0.5, 'a:row_crop'),
-    (1, 'a:row_crop'),
-    (2, 'a:row_crop'),
-    (3.2, 'a:row_crop'),
-    (8, 'a:row_crop'),
-    (0.5, 'a:woody_wetland'),
-    (0.5, 'a:herbaceous_wetland'),
-    (1, 'a:woody_wetland'),
-    (1, 'a:herbaceous_wetland'),
-    (2, 'a:woody_wetland'),
-    (2, 'a:herbaceous_wetland'),
-    (3.2, 'a:woody_wetland'),
-    (3.2, 'a:herbaceous_wetland'),
-    (8, 'a:woody_wetland'),
-    (8, 'a:herbaceous_wetland'),
-    (0.5, 'b:water'),
-    (1, 'b:water'),
-    (2, 'b:water'),
-    (3.2, 'b:water'),
-    (8, 'b:water'),
-    (0.5, 'b:rock'),
-    (1, 'b:rock'),
-    (2, 'b:rock'),
-    (3.2, 'b:rock'),
-    (8, 'b:rock'),
-    (0.5, 'b:urban_grass'),
-    (1, 'b:urban_grass'),
-    (2, 'b:urban_grass'),
-    (3.2, 'b:urban_grass'),
-    (8, 'b:urban_grass'),
-    (0.5, 'b:li_residential'),
-    (1, 'b:li_residential'),
-    (2, 'b:li_residential'),
-    (3.2, 'b:li_residential'),
-    (8, 'b:li_residential'),
-    (0.5, 'b:hi_residential'),
-    (1, 'b:hi_residential'),
-    (2, 'b:hi_residential'),
-    (3.2, 'b:hi_residential'),
-    (8, 'b:hi_residential'),
-    (0.5, 'b:commercial'),
-    (1, 'b:commercial'),
-    (2, 'b:commercial'),
-    (3.2, 'b:commercial'),
-    (8, 'b:commercial'),
+    (0.5, 'a:cultivated_crops'),
+    (1, 'a:cultivated_crops'),
+    (2, 'a:cultivated_crops'),
+    (3.2, 'a:cultivated_crops'),
+    (8, 'a:cultivated_crops'),
+    (0.5, 'a:woody_wetlands'),
+    (0.5, 'a:herbaceous_wetlands'),
+    (1, 'a:woody_wetlands'),
+    (1, 'a:herbaceous_wetlands'),
+    (2, 'a:woody_wetlands'),
+    (2, 'a:herbaceous_wetlands'),
+    (3.2, 'a:woody_wetlands'),
+    (3.2, 'a:herbaceous_wetlands'),
+    (8, 'a:woody_wetlands'),
+    (8, 'a:herbaceous_wetlands'),
+    (0.5, 'b:open_water'),
+    (1, 'b:open_water'),
+    (2, 'b:open_water'),
+    (3.2, 'b:open_water'),
+    (8, 'b:open_water'),
+    (0.5, 'b:barren_land'),
+    (1, 'b:barren_land'),
+    (2, 'b:barren_land'),
+    (3.2, 'b:barren_land'),
+    (8, 'b:barren_land'),
+    (0.5, 'b:developed_open'),
+    (1, 'b:developed_open'),
+    (2, 'b:developed_open'),
+    (3.2, 'b:developed_open'),
+    (8, 'b:developed_open'),
+    (0.5, 'b:developed_low'),
+    (1, 'b:developed_low'),
+    (2, 'b:developed_low'),
+    (3.2, 'b:developed_low'),
+    (8, 'b:developed_low'),
+    (0.5, 'b:developed_med'),
+    (1, 'b:developed_med'),
+    (2, 'b:developed_med'),
+    (3.2, 'b:developed_med'),
+    (8, 'b:developed_med'),
+    (0.5, 'b:developed_high'),
+    (1, 'b:developed_high'),
+    (2, 'b:developed_high'),
+    (3.2, 'b:developed_high'),
+    (8, 'b:developed_high'),
     (0.5, 'b:deciduous_forest'),
     (0.5, 'b:evergreen_forest'),
     (0.5, 'b:mixed_forest'),
@@ -155,51 +157,51 @@ INPUT = [
     (2, 'b:pasture'),
     (3.2, 'b:pasture'),
     (8, 'b:pasture'),
-    (0.5, 'b:row_crop'),
-    (1, 'b:row_crop'),
-    (2, 'b:row_crop'),
-    (3.2, 'b:row_crop'),
-    (8, 'b:row_crop'),
-    (0.5, 'b:woody_wetland'),
-    (0.5, 'b:herbaceous_wetland'),
-    (1, 'b:woody_wetland'),
-    (1, 'b:herbaceous_wetland'),
-    (2, 'b:woody_wetland'),
-    (2, 'b:herbaceous_wetland'),
-    (3.2, 'b:woody_wetland'),
-    (3.2, 'b:herbaceous_wetland'),
-    (8, 'b:woody_wetland'),
-    (8, 'b:herbaceous_wetland'),
-    (0.5, 'c:water'),
-    (1, 'c:water'),
-    (2, 'c:water'),
-    (3.2, 'c:water'),
-    (8, 'c:water'),
-    (0.5, 'c:rock'),
-    (1, 'c:rock'),
-    (2, 'c:rock'),
-    (3.2, 'c:rock'),
-    (8, 'c:rock'),
-    (0.5, 'c:urban_grass'),
-    (1, 'c:urban_grass'),
-    (2, 'c:urban_grass'),
-    (3.2, 'c:urban_grass'),
-    (8, 'c:urban_grass'),
-    (0.5, 'c:li_residential'),
-    (1, 'c:li_residential'),
-    (2, 'c:li_residential'),
-    (3.2, 'c:li_residential'),
-    (8, 'c:li_residential'),
-    (0.5, 'c:hi_residential'),
-    (1, 'c:hi_residential'),
-    (2, 'c:hi_residential'),
-    (3.2, 'c:hi_residential'),
-    (8, 'c:hi_residential'),
-    (0.5, 'c:commercial'),
-    (1, 'c:commercial'),
-    (2, 'c:commercial'),
-    (3.2, 'c:commercial'),
-    (8, 'c:commercial'),
+    (0.5, 'b:cultivated_crops'),
+    (1, 'b:cultivated_crops'),
+    (2, 'b:cultivated_crops'),
+    (3.2, 'b:cultivated_crops'),
+    (8, 'b:cultivated_crops'),
+    (0.5, 'b:woody_wetlands'),
+    (0.5, 'b:herbaceous_wetlands'),
+    (1, 'b:woody_wetlands'),
+    (1, 'b:herbaceous_wetlands'),
+    (2, 'b:woody_wetlands'),
+    (2, 'b:herbaceous_wetlands'),
+    (3.2, 'b:woody_wetlands'),
+    (3.2, 'b:herbaceous_wetlands'),
+    (8, 'b:woody_wetlands'),
+    (8, 'b:herbaceous_wetlands'),
+    (0.5, 'c:open_water'),
+    (1, 'c:open_water'),
+    (2, 'c:open_water'),
+    (3.2, 'c:open_water'),
+    (8, 'c:open_water'),
+    (0.5, 'c:barren_land'),
+    (1, 'c:barren_land'),
+    (2, 'c:barren_land'),
+    (3.2, 'c:barren_land'),
+    (8, 'c:barren_land'),
+    (0.5, 'c:developed_open'),
+    (1, 'c:developed_open'),
+    (2, 'c:developed_open'),
+    (3.2, 'c:developed_open'),
+    (8, 'c:developed_open'),
+    (0.5, 'c:developed_low'),
+    (1, 'c:developed_low'),
+    (2, 'c:developed_low'),
+    (3.2, 'c:developed_low'),
+    (8, 'c:developed_low'),
+    (0.5, 'c:developed_med'),
+    (1, 'c:developed_med'),
+    (2, 'c:developed_med'),
+    (3.2, 'c:developed_med'),
+    (8, 'c:developed_med'),
+    (0.5, 'c:developed_high'),
+    (1, 'c:developed_high'),
+    (2, 'c:developed_high'),
+    (3.2, 'c:developed_high'),
+    (8, 'c:developed_high'),
     (0.5, 'c:deciduous_forest'),
     (0.5, 'c:evergreen_forest'),
     (0.5, 'c:mixed_forest'),
@@ -225,51 +227,51 @@ INPUT = [
     (2, 'c:pasture'),
     (3.2, 'c:pasture'),
     (8, 'c:pasture'),
-    (0.5, 'c:row_crop'),
-    (1, 'c:row_crop'),
-    (2, 'c:row_crop'),
-    (3.2, 'c:row_crop'),
-    (8, 'c:row_crop'),
-    (0.5, 'c:woody_wetland'),
-    (0.5, 'c:herbaceous_wetland'),
-    (1, 'c:woody_wetland'),
-    (1, 'c:herbaceous_wetland'),
-    (2, 'c:woody_wetland'),
-    (2, 'c:herbaceous_wetland'),
-    (3.2, 'c:woody_wetland'),
-    (3.2, 'c:herbaceous_wetland'),
-    (8, 'c:woody_wetland'),
-    (8, 'c:herbaceous_wetland'),
-    (0.5, 'd:water'),
-    (1, 'd:water'),
-    (2, 'd:water'),
-    (3.2, 'd:water'),
-    (8, 'd:water'),
-    (0.5, 'd:rock'),
-    (1, 'd:rock'),
-    (2, 'd:rock'),
-    (3.2, 'd:rock'),
-    (8, 'd:rock'),
-    (0.5, 'd:urban_grass'),
-    (1, 'd:urban_grass'),
-    (2, 'd:urban_grass'),
-    (3.2, 'd:urban_grass'),
-    (8, 'd:urban_grass'),
-    (0.5, 'd:li_residential'),
-    (1, 'd:li_residential'),
-    (2, 'd:li_residential'),
-    (3.2, 'd:li_residential'),
-    (8, 'd:li_residential'),
-    (0.5, 'd:hi_residential'),
-    (1, 'd:hi_residential'),
-    (2, 'd:hi_residential'),
-    (3.2, 'd:hi_residential'),
-    (8, 'd:hi_residential'),
-    (0.5, 'd:commercial'),
-    (1, 'd:commercial'),
-    (2, 'd:commercial'),
-    (3.2, 'd:commercial'),
-    (8, 'd:commercial'),
+    (0.5, 'c:cultivated_crops'),
+    (1, 'c:cultivated_crops'),
+    (2, 'c:cultivated_crops'),
+    (3.2, 'c:cultivated_crops'),
+    (8, 'c:cultivated_crops'),
+    (0.5, 'c:woody_wetlands'),
+    (0.5, 'c:herbaceous_wetlands'),
+    (1, 'c:woody_wetlands'),
+    (1, 'c:herbaceous_wetlands'),
+    (2, 'c:woody_wetlands'),
+    (2, 'c:herbaceous_wetlands'),
+    (3.2, 'c:woody_wetlands'),
+    (3.2, 'c:herbaceous_wetlands'),
+    (8, 'c:woody_wetlands'),
+    (8, 'c:herbaceous_wetlands'),
+    (0.5, 'd:open_water'),
+    (1, 'd:open_water'),
+    (2, 'd:open_water'),
+    (3.2, 'd:open_water'),
+    (8, 'd:open_water'),
+    (0.5, 'd:barren_land'),
+    (1, 'd:barren_land'),
+    (2, 'd:barren_land'),
+    (3.2, 'd:barren_land'),
+    (8, 'd:barren_land'),
+    (0.5, 'd:developed_open'),
+    (1, 'd:developed_open'),
+    (2, 'd:developed_open'),
+    (3.2, 'd:developed_open'),
+    (8, 'd:developed_open'),
+    (0.5, 'd:developed_low'),
+    (1, 'd:developed_low'),
+    (2, 'd:developed_low'),
+    (3.2, 'd:developed_low'),
+    (8, 'd:developed_low'),
+    (0.5, 'd:developed_med'),
+    (1, 'd:developed_med'),
+    (2, 'd:developed_med'),
+    (3.2, 'd:developed_med'),
+    (8, 'd:developed_med'),
+    (0.5, 'd:developed_high'),
+    (1, 'd:developed_high'),
+    (2, 'd:developed_high'),
+    (3.2, 'd:developed_high'),
+    (8, 'd:developed_high'),
     (0.5, 'd:deciduous_forest'),
     (0.5, 'd:evergreen_forest'),
     (0.5, 'd:mixed_forest'),
@@ -295,21 +297,21 @@ INPUT = [
     (2, 'd:pasture'),
     (3.2, 'd:pasture'),
     (8, 'd:pasture'),
-    (0.5, 'd:row_crop'),
-    (1, 'd:row_crop'),
-    (2, 'd:row_crop'),
-    (3.2, 'd:row_crop'),
-    (8, 'd:row_crop'),
-    (0.5, 'd:woody_wetland'),
-    (0.5, 'd:herbaceous_wetland'),
-    (1, 'd:woody_wetland'),
-    (1, 'd:herbaceous_wetland'),
-    (2, 'd:woody_wetland'),
-    (2, 'd:herbaceous_wetland'),
-    (3.2, 'd:woody_wetland'),
-    (3.2, 'd:herbaceous_wetland'),
-    (8, 'd:woody_wetland'),
-    (8, 'd:herbaceous_wetland')
+    (0.5, 'd:cultivated_crops'),
+    (1, 'd:cultivated_crops'),
+    (2, 'd:cultivated_crops'),
+    (3.2, 'd:cultivated_crops'),
+    (8, 'd:cultivated_crops'),
+    (0.5, 'd:woody_wetlands'),
+    (0.5, 'd:herbaceous_wetlands'),
+    (1, 'd:woody_wetlands'),
+    (1, 'd:herbaceous_wetlands'),
+    (2, 'd:woody_wetlands'),
+    (2, 'd:herbaceous_wetlands'),
+    (3.2, 'd:woody_wetlands'),
+    (3.2, 'd:herbaceous_wetlands'),
+    (8, 'd:woody_wetlands'),
+    (8, 'd:herbaceous_wetlands')
 ]
 
 OUTPUT = [
@@ -598,13 +600,13 @@ OUTPUT = [
 CENSUS_1 = {
     'cell_count': 147,
     'distribution': {
-        'c:commercial': {
+        'c:developed_high': {
             'cell_count': 42
         },
         'a:deciduous_forest': {
             'cell_count': 72
         },
-        'd:hi_residential': {
+        'd:developed_med': {
             'cell_count': 33
         }
     },
@@ -613,16 +615,16 @@ CENSUS_1 = {
             'change': '::no_till',
             'cell_count': 30,
             'distribution': {
-                'c:commercial': {
+                'c:developed_high': {
                     'cell_count': 20
                 },
-                'd:hi_residential': {
+                'd:developed_med': {
                     'cell_count': 10
                 }
             }
         },
         {
-            'change': 'd:rock:',
+            'change': 'd:barren_land:',
             'cell_count': 5,
             'distribution': {
                 'a:deciduous_forest': {
@@ -642,7 +644,7 @@ YEAR_OUTPUT_1 = {
         'runoff': 17.614211721110824,
         'et': 15.167861632653095,
         'distribution': {
-            'c:commercial': {
+            'c:developed_high': {
                 'cell_count': 42,
                 'tp': 1.2321451541995787,
                 'tn': 7.786472849455671,
@@ -662,7 +664,7 @@ YEAR_OUTPUT_1 = {
                 'bod': 0.0,
                 'tss': 0.0
             },
-            'd:hi_residential': {
+            'd:developed_med': {
                 'cell_count': 33,
                 'tp': 0.6837058223430238,
                 'tn': 4.072508593956273,
@@ -684,7 +686,7 @@ YEAR_OUTPUT_1 = {
         'runoff': 11.957947247429287,
         'et': 20.450586122448982,
         'distribution': {
-            'c:commercial': {
+            'c:developed_high': {
                 'inf': 16.198443763932524,
                 'cell_count': 42,
                 'tp': 0.7192244464514511,
@@ -692,7 +694,7 @@ YEAR_OUTPUT_1 = {
                 'runoff': 21.23295052178176,
                 'et': 17.42526,
                 'distribution': {
-                    'c:commercial': {
+                    'c:developed_high': {
                         'cell_count': 22,
                         'tp': 0.6454093664854939,
                         'tn': 4.078628635429163,
@@ -702,7 +704,7 @@ YEAR_OUTPUT_1 = {
                         'bod': 555.7691766958419,
                         'tss': 113.35001998901487
                     },
-                    'c:commercial:no_till': {
+                    'c:developed_high:no_till': {
                         'cell_count': 20,
                         'tp': 0.07381507996595724,
                         'tn': 0.4664702970070909,
@@ -734,7 +736,7 @@ YEAR_OUTPUT_1 = {
                         'bod': 0.0,
                         'tss': 0.0
                     },
-                    'd:rock:': {
+                    'd:barren_land:': {
                         'cell_count': 5,
                         'tp': 0.0003225729096998572,
                         'tn': 0.0032257290969985716,
@@ -748,7 +750,7 @@ YEAR_OUTPUT_1 = {
                 'bod': 42.579624080381144,
                 'tss': 0.32257290969985714
             },
-            'd:hi_residential': {
+            'd:developed_med': {
                 'inf': 13.967458770273502,
                 'cell_count': 33,
                 'tp': 0.5206999354540374,
@@ -756,7 +758,7 @@ YEAR_OUTPUT_1 = {
                 'runoff': 24.498158107332266,
                 'et': 15.08352545454543,
                 'distribution': {
-                    'd:hi_residential:no_till': {
+                    'd:developed_med:no_till': {
                         'cell_count': 10,
                         'tp': 0.0441776956392026,
                         'tn': 0.26314540445959805,
@@ -766,7 +768,7 @@ YEAR_OUTPUT_1 = {
                         'bod': 45.3301572645731,
                         'tss': 5.416569639241362
                     },
-                    'd:hi_residential': {
+                    'd:developed_med': {
                         'cell_count': 23,
                         'tp': 0.47652223981483477,
                         'tn': 2.83841508063619,
@@ -795,7 +797,7 @@ DAY_OUTPUT_1 = {
         'runoff': 0.4408688415627653,
         'et': 0.08288448979591835,
         'distribution': {
-            'c:commercial': {
+            'c:developed_high': {
                 'cell_count': 42,
                 'tp': 0.03354942097300307,
                 'tn': 0.21201370198217218,
@@ -815,7 +817,7 @@ DAY_OUTPUT_1 = {
                 'bod': 0.0,
                 'tss': 0.0
             },
-            'd:hi_residential': {
+            'd:developed_med': {
                 'cell_count': 33,
                 'tp': 0.014948448154116101,
                 'tn': 0.08904075639625678,
@@ -837,7 +839,7 @@ DAY_OUTPUT_1 = {
         'runoff': 0.44386559426970806,
         'et': 0.11175183673469387,
         'distribution': {
-            'c:commercial': {
+            'c:developed_high': {
                 'inf': 1.077061870392374,
                 'cell_count': 42,
                 'tp': 0.02803732401552826,
@@ -845,7 +847,7 @@ DAY_OUTPUT_1 = {
                 'runoff': 0.827718129607626,
                 'et': 0.09522,
                 'distribution': {
-                    'c:commercial': {
+                    'c:developed_high': {
                         'cell_count': 22,
                         'tp': 0.017573506223953986,
                         'tn': 0.11105479627637589,
@@ -855,7 +857,7 @@ DAY_OUTPUT_1 = {
                         'bod': 15.132741470627044,
                         'tss': 3.086347030581919
                     },
-                    'c:commercial:no_till': {
+                    'c:developed_high:no_till': {
                         'cell_count': 20,
                         'tp': 0.010463817791574277,
                         'tn': 0.06612551521064301,
@@ -887,7 +889,7 @@ DAY_OUTPUT_1 = {
                         'bod': 0.0,
                         'tss': 0.0
                     },
-                    'd:rock:': {
+                    'd:barren_land:': {
                         'cell_count': 5,
                         'tp': 3.258553846153846e-05,
                         'tn': 0.0003258553846153846,
@@ -901,7 +903,7 @@ DAY_OUTPUT_1 = {
                 'bod': 4.301291076923077,
                 'tss': 0.032585538461538464
             },
-            'd:hi_residential': {
+            'd:developed_med': {
                 'inf': 1.1701229689350983,
                 'cell_count': 33,
                 'tp': 0.015886865154134316,
@@ -909,7 +911,7 @@ DAY_OUTPUT_1 = {
                 'runoff': 0.7474533947012655,
                 'et': 0.08242363636363635,
                 'distribution': {
-                    'd:hi_residential:no_till': {
+                    'd:developed_med:no_till': {
                         'cell_count': 10,
                         'tp': 0.005468249773992795,
                         'tn': 0.03257174865378317,
@@ -919,7 +921,7 @@ DAY_OUTPUT_1 = {
                         'bod': 5.610899768096954,
                         'tss': 0.6704549722895514
                     },
-                    'd:hi_residential': {
+                    'd:developed_med': {
                         'cell_count': 23,
                         'tp': 0.010418615380141523,
                         'tn': 0.06205870900345169,
@@ -942,8 +944,8 @@ DAY_OUTPUT_1 = {
 CENSUS_2 = {
     'cell_count': 4,
     'distribution': {
-        'd:hi_residential': {'cell_count': 1},
-        'c:commercial': {'cell_count': 1},
+        'd:developed_med': {'cell_count': 1},
+        'c:developed_high': {'cell_count': 1},
         'a:deciduous_forest': {'cell_count': 1},
         'b:pasture': {'cell_count': 1}
     },
@@ -959,14 +961,14 @@ CENSUS_2 = {
             'change': '::cluster_housing',
             'cell_count': 1,
             'distribution': {
-                'd:hi_residential': {'cell_count': 1}
+                'd:developed_med': {'cell_count': 1}
             }
         },
         {
             'change': '::rain_garden',
             'cell_count': 1,
             'distribution': {
-                'c:commercial': {'cell_count': 1}
+                'c:developed_high': {'cell_count': 1}
             }
         }
     ]
@@ -981,7 +983,7 @@ DAY_OUTPUT_2 = {
         'runoff': 0.4417192317490494,
         'et': 0.07969499999999999,
         'distribution': {
-            'c:commercial': {
+            'c:developed_high': {
                 'cell_count': 1,
                 'tp': 0.0007987957374524541,
                 'tn': 0.005047945285289814,
@@ -1011,7 +1013,7 @@ DAY_OUTPUT_2 = {
                 'bod': 0.04095699629825491,
                 'tss': 0.020478498149127455
             },
-            'd:hi_residential': {
+            'd:developed_med': {
                 'cell_count': 1,
                 'tp': 0.0004529832773974576,
                 'tn': 0.002698204739280508,
@@ -1033,7 +1035,7 @@ DAY_OUTPUT_2 = {
         'runoff': 0.3934343798309537,
         'et': 0.108675,
         'distribution': {
-            'c:commercial': {
+            'c:developed_high': {
                 'inf': 1.0641101843915999,
                 'cell_count': 1,
                 'tp': 0.0007414402317520271,
@@ -1041,13 +1043,13 @@ DAY_OUTPUT_2 = {
                 'runoff': 0.9193298156084,
                 'et': 0.01656,
                 'distribution': {
-                    'c:commercial': {
+                    'c:developed_high': {
                         'cell_count': 0,
                         'runoff': 0,
                         'et': 0,
                         'inf': 0
                     },
-                    'c:commercial:rain_garden': {
+                    'c:developed_high:rain_garden': {
                         'cell_count': 1,
                         'tp': 0.0007414402317520271,
                         'tn': 0.004685490353432948,
@@ -1099,7 +1101,7 @@ DAY_OUTPUT_2 = {
                 'bod': 0.1793851691515932,
                 'tss': 0.0896925845757966
             },
-            'd:hi_residential': {
+            'd:developed_med': {
                 'inf': 1.5789429191559998,
                 'cell_count': 1,
                 'tp': 0.000215198296488544,
@@ -1107,7 +1109,7 @@ DAY_OUTPUT_2 = {
                 'runoff': 0.3341170808440001,
                 'et': 0.08693999999999999,
                 'distribution': {
-                    'd:hi_residential:cluster_housing': {
+                    'd:developed_med:cluster_housing': {
                         'cell_count': 1,
                         'tp': 0.000215198296488544,
                         'tn': 0.001281833331257849,
@@ -1117,7 +1119,7 @@ DAY_OUTPUT_2 = {
                         'bod': 0.220812165092593,
                         'tss': 0.026385182439030177
                     },
-                    'd:hi_residential': {
+                    'd:developed_med': {
                         'cell_count': 0,
                         'runoff': 0,
                         'et': 0,
@@ -1142,7 +1144,7 @@ YEAR_OUTPUT_2 = {
         'runoff': 17.232718905670666,
         'et': 14.58418499999997,
         'distribution': {
-            'c:commercial': {
+            'c:developed_high': {
                 'cell_count': 1,
                 'tp': 0.029336789385704252,
                 'tn': 0.1853922107013255,
@@ -1172,7 +1174,7 @@ YEAR_OUTPUT_2 = {
                 'bod': 0.21738140515342014,
                 'tss': 0.10869070257671007
             },
-            'd:hi_residential': {
+            'd:developed_med': {
                 'cell_count': 1,
                 'tp': 0.020718358252818894,
                 'tn': 0.1234093513320082,
@@ -1187,14 +1189,14 @@ YEAR_OUTPUT_2 = {
         'tss': 7.801215219873598
     },
     'modified': {
-        'inf': 24.476938587987863,
+        'inf': 24.47693858798786,
         'cell_count': 4,
         'tp': 0.038879611034946346,
         'tn': 0.24507035546075562,
         'runoff': 12.571429731923587,
-        'et': 19.887524999999986,
+        'et': 19.887524999999982,
         'distribution': {
-            'c:commercial': {
+            'c:developed_high': {
                 'inf': 11.893415183645322,
                 'cell_count': 1,
                 'tp': 0.02310848228996424,
@@ -1202,13 +1204,13 @@ YEAR_OUTPUT_2 = {
                 'runoff': 28.652770449780387,
                 'et': 3.0304800000000034,
                 'distribution': {
-                    'c:commercial': {
+                    'c:developed_high': {
                         'cell_count': 0,
                         'runoff': 0,
                         'et': 0,
                         'inf': 0
                     },
-                    'c:commercial:rain_garden': {
+                    'c:developed_high:rain_garden': {
                         'cell_count': 1,
                         'tp': 0.02310848228996424,
                         'tn': 0.14603277002685733,
@@ -1260,7 +1262,7 @@ YEAR_OUTPUT_2 = {
                 'bod': 0.9933883637043449,
                 'tss': 0.49669418185217246
             },
-            'd:hi_residential': {
+            'd:developed_med': {
                 'inf': 19.15002524987511,
                 'cell_count': 1,
                 'tp': 0.012790963653869069,
@@ -1268,7 +1270,7 @@ YEAR_OUTPUT_2 = {
                 'runoff': 19.859262396344974,
                 'et': 15.910020000000028,
                 'distribution': {
-                    'd:hi_residential:cluster_housing': {
+                    'd:developed_med:cluster_housing': {
                         'cell_count': 1,
                         'tp': 0.012790963653869069,
                         'tn': 0.07618965306869836,
@@ -1278,7 +1280,7 @@ YEAR_OUTPUT_2 = {
                         'bod': 13.124640966578697,
                         'tss': 1.568283369735251
                     },
-                    'd:hi_residential': {
+                    'd:developed_med': {
                         'cell_count': 0,
                         'runoff': 0,
                         'et': 0,
@@ -1330,7 +1332,7 @@ class TestModel(unittest.TestCase):
         self.assertEqual(runoffs, CN80)
 
         # This pair has CN=90
-        runoffs = [round(runoff_nrcs(precip, 0.0, 'c', 'hi_residential'), 2)
+        runoffs = [round(runoff_nrcs(precip, 0.0, 'c', 'developed_med'), 2)
                    for precip in PS]
         self.assertEqual(runoffs, CN90)
 
@@ -1351,10 +1353,10 @@ class TestModel(unittest.TestCase):
             lam = lambda x, y: abs(x - y) / precip
             me = average(map(lam, results, expected))
             # Precipitation levels <= 2 inches are known to be
-            # problematic.  It is unclear why the 'rock' type is
+            # problematic.  It is unclear why the 'barren_land' type is
             # giving trouble on soil types C and D.
-            if precip > 2 and tile_string != 'c:rock' \
-               and tile_string != 'd:rock':
+            if precip > 2 and tile_string != 'c:barren_land' \
+               and tile_string != 'd:barren_land':
                 self.assertTrue(me < 0.04, tile_string + ' ' + str(me))
         map(similar, INPUT, OUTPUT)
 
@@ -1369,12 +1371,12 @@ class TestModel(unittest.TestCase):
         # sample output that was mailed to us.
         results = [simulate(precip, tile_string + ':')['runoff-vol'] / precip
                    for precip, tile_string in INPUT
-                   if precip > 2 and tile_string != 'c:rock' and
-                   tile_string != 'd:rock']
+                   if precip > 2 and tile_string != 'c:barren_land' and
+                   tile_string != 'd:barren_land']
         expected = [OUTPUT[i][0] / INPUT[i][0]
                     for i in range(len(INPUT))
-                    if INPUT[i][0] > 2 and INPUT[i][1] != 'c:rock' and
-                    INPUT[i][1] != 'd:rock']
+                    if INPUT[i][0] > 2 and INPUT[i][1] != 'c:barren_land' and
+                    INPUT[i][1] != 'd:barren_land']
         lam = lambda x, y: pow((x - y), 2)
         rmse = sqrt(average(map(lam, results, expected)))
         self.assertTrue(rmse < 0.13)
@@ -1383,15 +1385,15 @@ class TestModel(unittest.TestCase):
         """
         Daily simulation.
         """
-        result1 = simulate_cell_day(42, 93, 'a:rock:', 1)
-        result2 = simulate_cell_day(42, 93, 'a:rock:', 2)
+        result1 = simulate_cell_day(42, 93, 'a:barren_land:', 1)
+        result2 = simulate_cell_day(42, 93, 'a:barren_land:', 2)
         self.assertEqual(result1['runoff-vol'] * 2, result2['runoff-vol'])
 
     def test_simulate_cell_year(self):
         """
         Yearly simulation.
         """
-        result1 = simulate_cell_year('a:hi_residential:', 42)
+        result1 = simulate_cell_year('a:developed_med:', 42)
         result2 = simulate_cell_year('a:mixed_forest:', 42)
         self.assertNotEqual(result1, result2)
         self.assertGreater(result1['runoff-vol'], result2['runoff-vol'])
@@ -1403,15 +1405,15 @@ class TestModel(unittest.TestCase):
         census = {
             "cell_count": 2,
             "distribution": {
-                "a:rock": {"cell_count": 1},
-                "a:water": {"cell_count": 1}
+                "a:barren_land": {"cell_count": 1},
+                "a:open_water": {"cell_count": 1}
             },
             "modifications": [
                 {
                     "change": "::cluster_housing",
                     "cell_count": 1,
                     "distribution": {
-                        "a:rock": {"cell_count": 1}
+                        "a:barren_land": {"cell_count": 1}
                     }
                 }
             ]
@@ -1428,8 +1430,8 @@ class TestModel(unittest.TestCase):
         census = {
             "cell_count": 5,
             "distribution": {
-                "a:rock": {"cell_count": 3},
-                "a:water": {"cell_count": 2}
+                "a:barren_land": {"cell_count": 3},
+                "a:open_water": {"cell_count": 2}
             }
         }
 
@@ -1444,8 +1446,8 @@ class TestModel(unittest.TestCase):
         census = {
             "cell_count": 3,
             "distribution": {
-                "a:rock": {"cell_count": 2},
-                "a:water": {"cell_count": 1}
+                "a:barren_land": {"cell_count": 2},
+                "a:open_water": {"cell_count": 1}
             },
             "modifications": []
         }
@@ -1461,15 +1463,15 @@ class TestModel(unittest.TestCase):
         census1 = {
             "cell_count": 144,
             "distribution": {
-                "a:rock": {"cell_count": 55},
-                "a:water": {"cell_count": 89}
+                "a:barren_land": {"cell_count": 55},
+                "a:open_water": {"cell_count": 89}
             },
             "modifications": [
                 {
                     "change": "::cluster_housing",
                     "cell_count": 34,
                     "distribution": {
-                        "a:rock": {"cell_count": 34}
+                        "a:barren_land": {"cell_count": 34}
                     }
                 }
             ]
@@ -1478,14 +1480,14 @@ class TestModel(unittest.TestCase):
         census2 = {
             "cell_count": 144,
             "distribution": {
-                "a:rock": {
+                "a:barren_land": {
                     "cell_count": 55,
                     "distribution": {
-                        "a:rock:cluster_housing": {"cell_count": 34},
-                        "a:rock": {"cell_count": 21}
+                        "a:barren_land:cluster_housing": {"cell_count": 34},
+                        "a:barren_land": {"cell_count": 21}
                     }
                 },
-                "a:water": {"cell_count": 89}
+                "a:open_water": {"cell_count": 89}
             }
         }
 
@@ -1498,7 +1500,7 @@ class TestModel(unittest.TestCase):
         """
         census = {
             "distribution": {
-                "a:li_residential": {
+                "a:developed_low": {
                     "cell_count": 3
                 }
             },
@@ -1506,7 +1508,7 @@ class TestModel(unittest.TestCase):
             "modifications": [
                 {
                     "distribution": {
-                        "a:li_residential": {
+                        "a:developed_low": {
                             "cell_count": 1
                         }
                     },
@@ -1515,7 +1517,7 @@ class TestModel(unittest.TestCase):
                 },
                 {
                     "distribution": {
-                        "a:li_residential": {
+                        "a:developed_low": {
                             "cell_count": 1
                         }
                     },
@@ -1524,7 +1526,7 @@ class TestModel(unittest.TestCase):
                 },
                 {
                     "distribution": {
-                        "a:li_residential": {
+                        "a:developed_low": {
                             "cell_count": 1
                         }
                     },
@@ -1536,11 +1538,11 @@ class TestModel(unittest.TestCase):
 
         expected = set([
             'a:deciduous_forest:',
-            'a:li_residential',
+            'a:developed_low',
             'a:deciduous_forest:cluster_housing',
-            'a:li_residential:cluster_housing'])
+            'a:developed_low:cluster_housing'])
         modified = create_modified_census(census)
-        distrib = modified['distribution']['a:li_residential']['distribution']
+        distrib = modified['distribution']['a:developed_low']['distribution']
         actual = set(distrib.keys())
         self.assertEqual(actual, expected)
 
@@ -1551,8 +1553,8 @@ class TestModel(unittest.TestCase):
         census = {
             "cell_count": 5,
             "distribution": {
-                "a:rock": {"cell_count": 3},
-                "a:water": {"cell_count": 2}
+                "a:barren_land": {"cell_count": 3},
+                "a:open_water": {"cell_count": 2}
             }
         }
 
@@ -1560,8 +1562,8 @@ class TestModel(unittest.TestCase):
             return simulate_cell_year(cell, cell_count)
 
         simulate_water_quality(census, 93, fn)
-        left = census['distribution']['a:rock']
-        right = census['distribution']['a:water']
+        left = census['distribution']['a:barren_land']
+        right = census['distribution']['a:open_water']
         for key in set(census.keys()) - set(['distribution']):
             self.assertEqual(left[key] + right[key], census[key])
 
@@ -1572,15 +1574,15 @@ class TestModel(unittest.TestCase):
         census = {
             "cell_count": 2,
             "distribution": {
-                "a:rock": {"cell_count": 1},
-                "a:water": {"cell_count": 1}
+                "a:barren_land": {"cell_count": 1},
+                "a:open_water": {"cell_count": 1}
             },
             "modifications": [
                 {
-                    "change": "d:hi_residential:",
+                    "change": "d:developed_med:",
                     "cell_count": 1,
                     "distribution": {
-                        "a:rock": {"cell_count": 1}
+                        "a:barren_land": {"cell_count": 1}
                     }
                 }
             ]
@@ -1590,8 +1592,8 @@ class TestModel(unittest.TestCase):
         census2 = {
             "cell_count": 2,
             "distribution": {
-                "d:hi_residential": {"cell_count": 1},
-                "a:water": {"cell_count": 1}
+                "d:developed_med": {"cell_count": 1},
+                "a:open_water": {"cell_count": 1}
             }
         }
 
@@ -1610,14 +1612,14 @@ class TestModel(unittest.TestCase):
         census1 = {
             "cell_count": 8,
             "distribution": {
-                "a:hi_residential": {"cell_count": 1},
+                "a:developed_med": {"cell_count": 1},
                 "b:no_till": {"cell_count": 1},
                 "c:pasture": {"cell_count": 1},
-                "d:row_crop": {"cell_count": 1},
-                "a:water": {"cell_count": 1},
-                "b:chaparral": {"cell_count": 1},
-                "c:desert": {"cell_count": 1},
-                "d:tall_grass_prairie": {"cell_count": 1}
+                "d:cultivated_crops": {"cell_count": 1},
+                "a:open_water": {"cell_count": 1},
+                "b:shrub": {"cell_count": 1},
+                "c:barren_land": {"cell_count": 1},
+                "d:developed_open": {"cell_count": 1}
             }
         }
 
@@ -1627,11 +1629,10 @@ class TestModel(unittest.TestCase):
                 "a:mixed_forest": {"cell_count": 1},
                 "b:mixed_forest": {"cell_count": 1},
                 "c:mixed_forest": {"cell_count": 1},
-                "d:mixed_forest": {"cell_count": 1},
-                "a:water": {"cell_count": 1},
-                "b:chaparral": {"cell_count": 1},
-                "c:desert": {"cell_count": 1},
-                "d:tall_grass_prairie": {"cell_count": 1}
+                "d:mixed_forest": {"cell_count": 2},
+                "a:open_water": {"cell_count": 1},
+                "b:shrub": {"cell_count": 1},
+                "c:barren_land": {"cell_count": 1}
             }
         }
 

--- a/test/test_tablelookup.py
+++ b/test/test_tablelookup.py
@@ -20,13 +20,13 @@ class TestTablelookups(unittest.TestCase):
         """
         Do some spot-checks on the SampleYear data.
         """
-        self.assertEqual(lookup_pet(0, 'water')[0], 0.0)
-        self.assertEqual(lookup_pet(52, 'hi_residential')[1], 0.0)
+        self.assertEqual(lookup_pet(0, 'open_water')[0], 0.0)
+        self.assertEqual(lookup_pet(52, 'developed_med')[1], 0.0)
         self.assertEqual(lookup_pet(104, 'green_roof')[1], 0.0)
         self.assertEqual(lookup_pet(156, 'cluster_housing')[0], 0.23)
         self.assertEqual(lookup_pet(208, 'grassland')[0], 0.2)
-        self.assertEqual(lookup_pet(260, 'woody_wetland')[1], 0.207)
-        self.assertEqual(lookup_pet(352, 'hay')[1], 0.207 * 0.6)
+        self.assertEqual(lookup_pet(260, 'woody_wetlands')[1], 0.207)
+        self.assertEqual(lookup_pet(352, 'pasture')[1], 0.207 * 0.6)
 
     def test_lookup_bmp_infiltration(self):
         """
@@ -41,11 +41,11 @@ class TestTablelookups(unittest.TestCase):
         """
         Do some spot-checks on the data from Table C.
         """
-        self.assertEqual(lookup_cn('a', 'water'), 100)
-        self.assertEqual(lookup_cn('b', 'li_residential'), 68)
-        self.assertEqual(lookup_cn('c', 'hi_residential'), 90)
-        self.assertEqual(lookup_cn('d', 'commercial'), 95)
-        self.assertEqual(lookup_cn('a', 'rock'), 77)
+        self.assertEqual(lookup_cn('a', 'open_water'), 100)
+        self.assertEqual(lookup_cn('b', 'developed_low'), 68)
+        self.assertEqual(lookup_cn('c', 'developed_med'), 90)
+        self.assertEqual(lookup_cn('d', 'developed_high'), 95)
+        self.assertEqual(lookup_cn('a', 'barren_land'), 77)
         self.assertEqual(lookup_cn('b', 'deciduous_forest'), 55)
         self.assertEqual(lookup_cn('c', 'evergreen_forest'), 70)
         self.assertEqual(lookup_cn('d', 'mixed_forest'), 77)

--- a/test/test_water_quality.py
+++ b/test/test_water_quality.py
@@ -32,7 +32,7 @@ class TestWaterQuality(unittest.TestCase):
         runoff_liters = 1000
 
         expected = ((runoff_liters * emc) / 1000000) * 2.205
-        load = get_pollutant_load('commercial', pollutant, runoff_liters)
+        load = get_pollutant_load('developed_high', pollutant, runoff_liters)
 
         self.assertEquals(expected, load)
 
@@ -40,5 +40,5 @@ class TestWaterQuality(unittest.TestCase):
         self.assertRaises(Exception, get_pollutant_load, 'asdf', 'tn', 1000)
 
     def test_load_bad_pollutant(self):
-        self.assertRaises(Exception, get_pollutant_load, 'commercial',
+        self.assertRaises(Exception, get_pollutant_load, 'developed_high',
                           'asdf', 1000)

--- a/tr55/makeMiniAppTable.py
+++ b/tr55/makeMiniAppTable.py
@@ -22,23 +22,23 @@ with open(csv_file_name, 'wb') as csv_file:
     # values of inputs to the model
     precips = [0.5, 1.0, 2.0, 3.2, 8.0]
 
-    # The land uses in the original mini-app were low intensity
-    # residential, high intensity residential, commercial, grassland, forest,
-    # turf grass, pasture, row crops. The closest matching to the values in
-    # this implementation of TR-55 are the following:
+    # The land uses in the original mini-app used non NLCD types
+    # (residential, high intensity residential, commercial, etc.) These were
+    # converted to the best matches from the NLCD types based on the NLCD
+    # number being used for the calculations in tables.py.
     land_uses = [
-        'li_residential',
-        'hi_residential',
-        'commercial',
-        'grassland',
+        'open_water',
+        'developed_open',
+        'developed_low',
+        'developed_med',
+        'developed_high',
+        'barren_land',
         'deciduous_forest',
-        'urban_grass',
+        'shrub',
+        'grassland',
         'pasture',
-        'row_crop',
-        'chaparral',
-        'tall_grass_prairie',
-        'short_grass_prairie',
-        'desert'
+        'cultivated_crops',
+        'woody_wetlands'
     ]
 
     soil_types = ['a', 'b', 'c', 'd']

--- a/tr55/model.py
+++ b/tr55/model.py
@@ -45,14 +45,12 @@ def runoff_pitt(precip, land_use):
     urb_grass = (c5 * p4) + (c6 * p3) + (c7 * p2) + (c8 * precip) + c9
 
     runoff_vals = {
-        'water':           impervious,
-        'li_residential':  0.20 * impervious + 0.80 * urb_grass,
+        'open_water':           impervious,
+        'developed_low':  0.20 * impervious + 0.80 * urb_grass,
         'cluster_housing': 0.20 * impervious + 0.80 * urb_grass,
-        'hi_residential':  0.65 * impervious + 0.35 * urb_grass,
-        'commercial':      impervious,
-        'industrial':      impervious,
-        'transportation':  impervious,
-        'urban_grass':     urb_grass
+        'developed_med':  0.65 * impervious + 0.35 * urb_grass,
+        'developed_high':      impervious,
+        'developed_open':     urb_grass
     }
 
     if land_use not in runoff_vals:
@@ -78,7 +76,7 @@ def runoff_nrcs(precip, evaptrans, soil_type, land_use):
     runoff value in inches.
     """
     if land_use == 'cluster_housing':
-        land_use = 'li_residential'
+        land_use = 'developed_low'
     curve_number = lookup_cn(soil_type, land_use)
     if nrcs_cutoff(precip, curve_number):
         return 0.0
@@ -137,7 +135,7 @@ def simulate_cell_day(precip, evaptrans, cell, cell_count):
         # intensity residential.
         inf = lookup_bmp_infiltration(soil_type, bmp)
         runoff = precip - (evaptrans + inf)
-        hi_res_cell = soil_type + ':hi_residential:'
+        hi_res_cell = soil_type + ':developed_med:'
         hi_res = simulate_cell_day(precip, evaptrans, hi_res_cell, 1)
         hir_run = hi_res['runoff-vol']
         hir_et = hi_res['et-vol']
@@ -184,10 +182,9 @@ def simulate_cell_year(cell, cell_count):
 
     The `cell_count` parameter is the number of cells of this type.
 
-    If the `precolumbian` parameter is true, then the cell is
-    simulated under Pre-Columbian circumstances (anything other than
-    water, woody wetland, and herbaceous wetland becomes mixed
-    forest).
+    If the `precolumbian` parameter is true, then the cell i simulated under
+    Pre-Columbian circumstances (anything other than the non-natural types
+    listed in tables.py becomes mixed forest).
     """
     split = cell.split(':')
     if (len(split) == 2):

--- a/tr55/tables.py
+++ b/tr55/tables.py
@@ -377,37 +377,26 @@ SAMPLE_YEAR = [
     (0.00, 0.207)
 ]
 
-
-# Land use descriptions may map to the same nlcd code and have the same values
-# but could be handled differently in the model execution (ex, commercial,
-# industrial, transportation). Describes the NLCD class value, the landscape
-# factor (ki) and the Curve Numbers for each hydrologic soil group for that use
-# type.
+# Describes the NLCD class value, the landscape factor (ki) and the Curve
+# Numbers for each hydrologic soil group for that use type.
 # NOTE: Missing NLCD type 12 (plus all Alaska only types (51, 72-74)
 LAND_USE_VALUES = {
-    'water':                {'nlcd': 11, 'ki': 0.0, 'cn': {'a': 100, 'b': 100, 'c': 100, 'd': 100}},  # noqa
-    'li_residential':       {'nlcd': 22, 'ki': 0.42, 'cn': {'a': 51, 'b': 68, 'c': 79, 'd': 84}},  # noqa
-    'hi_residential':       {'nlcd': 23, 'ki': 0.18, 'cn': {'a': 77, 'b': 85, 'c': 90, 'd': 92}},  # noqa
-    'commercial':           {'nlcd': 24, 'ki': 0.06, 'cn': {'a': 89, 'b': 92, 'c': 94, 'd': 95}},  # noqa
-    'industrial':           {'nlcd': 24, 'ki': 0.06, 'cn': {'a': 89, 'b': 92, 'c': 94, 'd': 95}},  # noqa
-    'transportation':       {'nlcd': 24, 'ki': 0.06, 'cn': {'a': 89, 'b': 92, 'c': 94, 'd': 95}},  # noqa
-    'rock':                 {'nlcd': 31, 'ki': 0.0, 'cn': {'a': 77, 'b': 86, 'c': 86, 'd': 91}},  # noqa
-    'sand':                 {'nlcd': 31, 'ki': 0.0, 'cn': {'a': 77, 'b': 86, 'c': 86, 'd': 91}},  # noqa
-    'clay':                 {'nlcd': 31, 'ki': 0.0, 'cn': {'a': 77, 'b': 86, 'c': 86, 'd': 91}},  # noqa
+    'open_water':           {'nlcd': 11, 'ki': 0.0, 'cn': {'a': 100, 'b': 100, 'c': 100, 'd': 100}},  # noqa
+    #'perennial_ice':        {'nlcd': 12, 'ki': 0.0, 'cn': {'a': 100, 'b': 100, 'c': 100, 'd': 100}},  # noqa
+    'developed_open':       {'nlcd': 21, 'ki': 0.7, 'cn': {'a': 68, 'b': 79, 'c': 86, 'd': 89}},  # noqa
+    'developed_low':        {'nlcd': 22, 'ki': 0.42, 'cn': {'a': 51, 'b': 68, 'c': 79, 'd': 84}},  # noqa
+    'developed_med':        {'nlcd': 23, 'ki': 0.18, 'cn': {'a': 77, 'b': 85, 'c': 90, 'd': 92}},  # noqa
+    'developed_high':       {'nlcd': 24, 'ki': 0.06, 'cn': {'a': 89, 'b': 92, 'c': 94, 'd': 95}},  # noqa
+    'barren_land':          {'nlcd': 31, 'ki': 0.0, 'cn': {'a': 77, 'b': 86, 'c': 86, 'd': 91}},  # noqa
     'deciduous_forest':     {'nlcd': 41, 'ki': 0.7, 'cn': {'a': 30, 'b': 55, 'c': 70, 'd': 77}},  # noqa
     'evergreen_forest':     {'nlcd': 42, 'ki': 0.7, 'cn': {'a': 30, 'b': 55, 'c': 70, 'd': 77}},  # noqa
     'mixed_forest':         {'nlcd': 43, 'ki': 0.7, 'cn': {'a': 30, 'b': 55, 'c': 70, 'd': 77}},  # noqa
+    'shrub':                {'nlcd': 52, 'ki': 1, 'cn': {'a': 35, 'b': 56, 'c': 70, 'd': 77}},  # noqa
     'grassland':            {'nlcd': 71, 'ki': 0.6, 'cn': {'a': 30, 'b': 58, 'c': 71, 'd': 78}},  # noqa
     'pasture':              {'nlcd': 81, 'ki': 0.6, 'cn': {'a': 39, 'b': 61, 'c': 74, 'd': 80}},  # noqa
-    'hay':                  {'nlcd': 81, 'ki': 0.6, 'cn': {'a': 39, 'b': 61, 'c': 74, 'd': 80}},  # noqa
-    'row_crop':             {'nlcd': 82, 'ki': 0.9, 'cn': {'a': 67, 'b': 78, 'c': 85, 'd': 89}},  # noqa
-    'urban_grass':          {'nlcd': 21, 'ki': 0.7, 'cn': {'a': 68, 'b': 79, 'c': 86, 'd': 89}},  # noqa
-    'woody_wetland':        {'nlcd': 90, 'ki': 1, 'cn': {'a': 98, 'b': 98, 'c': 98, 'd': 98}},  # noqa
-    'herbaceous_wetland':   {'nlcd': 95, 'ki': 1, 'cn': {'a': 98, 'b': 98, 'c': 98, 'd': 98}},  # noqa
-    'chaparral':            {'nlcd': 52, 'ki': 1, 'cn': {'a': 35, 'b': 56, 'c': 70, 'd': 77}},  # noqa
-    'tall_grass_prairie':   {'nlcd': 21, 'ki': 0.7, 'cn': {'a': 68, 'b': 79, 'c': 86, 'd': 89}},  # noqa
-    'short_grass_prairie':  {'nlcd': 81, 'ki': 0.6, 'cn': {'a': 39, 'b': 61, 'c': 74, 'd': 80}},  # noqa
-    'desert':               {'nlcd': 31, 'ki': 0.0, 'cn': {'a': 77, 'b': 86, 'c': 86, 'd': 91}},  # noqa
+    'cultivated_crops':     {'nlcd': 82, 'ki': 0.9, 'cn': {'a': 67, 'b': 78, 'c': 85, 'd': 89}},  # noqa
+    'woody_wetlands':       {'nlcd': 90, 'ki': 1, 'cn': {'a': 98, 'b': 98, 'c': 98, 'd': 98}},  # noqa
+    'herbaceous_wetlands':  {'nlcd': 95, 'ki': 1, 'cn': {'a': 98, 'b': 98, 'c': 98, 'd': 98}},  # noqa
 
     'green_roof':           {'ki': 0.4, 'infiltration': {'a': 1.6, 'b': 1.6, 'c': 1.6, 'd': 1.6}},  # noqa
     'porous_paving':        {'ki': 0.0, 'infiltration': {'a': 7.73, 'b': 4.13, 'c': 1.73}},  # noqa
@@ -424,12 +413,11 @@ BMPS = set(['green_roof', 'porous_paving',
             'rain_garden', 'infiltration_trench'])
 
 # The set of "built" land uses
-BUILT_TYPES = set(['li_residential', 'hi_residential', 'cluster_housing',
-                   'commercial', 'industrial', 'transportation',
-                   'urban_grass'])
+BUILT_TYPES = set(['developed_low', 'developed_med', 'cluster_housing',
+                   'developed_high'])
 
-NON_NATURAL = set(['pasture', 'hay', 'row_crop', 'green_roof']) \
-    | set(['no_till']) | BMPS | BUILT_TYPES
+NON_NATURAL = set(['pasture', 'cultivated_crops', 'green_roof',
+                   'developed_open']) | set(['no_till']) | BMPS | BUILT_TYPES
 
 # The set of pollutants that we are concerned with.
 POLLUTANTS = set(['tn', 'tp', 'bod', 'tss'])

--- a/tr55/water_quality.py
+++ b/tr55/water_quality.py
@@ -16,7 +16,8 @@ def get_volume_of_runoff(runoff, cell_count, cell_resolution):
 
         cell_count (integer): The number of cells included in the area
 
-        cell_resolution (number): The size in square meters that a cell represents
+        cell_resolution (number): The size in square meters that a cell
+        represents
 
     Returns:
         The volume of runoff liters in of the total area of interest


### PR DESCRIPTION
Related to https://github.com/WikiWatershed/model-my-watershed/issues/765

Rework all the strings and tests so that the keys used to run a tr55 model match those used by NLCD.

Note that I intend to squash this all to a single commit (or two) but I used single commits to test after each rename and it will probably make it easier to review in smaller chunks. 