### PR TITLE
Make sure runoff is non-zero

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ from __future__ import division
 
 import pprint
 
-from tr55.model import simulate_year
+from tr55.model import simulate_day
 
 census = {
     "cell_count": 147,
@@ -165,42 +165,42 @@ census = {
     ]
 }
 
-pprint.pprint(simulate_year(census))
+pprint.pprint(simulate_day(census, 0.984))
 ```
 is partially reproduced here:
 ```Python
- 'unmodified': {'bod': 1762.555509187117,
-                'cell_count': 147,
-                'distribution': {'a:deciduous_forest': {'bod': 0.0,
-                                                        'cell_count': 72,
-                                                        'et': 26.51670000000007,
-                                                        'inf': 34.91810000000001,
-                                                        'runoff': 0.0,
-                                                        'tn': 0.0,
-                                                        'tp': 0.0,
-                                                        'tss': 0.0},
-                                 'c:developed_high': {'bod': 1061.0138827829708,
-                                                  'cell_count': 42,
-                                                  'et': 2.272860000000005,
-                                                  'inf': 4.430079770137537,
-                                                  'runoff': 36.375400229862464,
-                                                  'tn': 7.786472849455671,
-                                                  'tp': 1.2321451541995787,
-                                                  'tss': 216.39549270630107},
-                                 'd:developed_med': {'bod': 701.5416264041463,
-                                                      'cell_count': 33,
-                                                      'et': 6.818579999999993,
-                                                      'inf': 8.361629213022574,
-                                                      'runoff': 32.167342828759615,
-                                                      'tn': 4.072508593956273,
-                                                      'tp': 0.6837058223430238,
-                                                      'tss': 83.8282790872751}},
-                'et': 15.167861632653095,
-                'inf': 20.24558036990151,
-                'runoff': 17.614211721110824,
-                'tn': 11.858981443411944,
-                'tp': 1.9158509765426026,
-                'tss': 300.2237717935762}
+u'unmodified': {u'bod': 43.11309178874012,
+                 u'cell_count': 147,
+                 u'distribution': {u'a:deciduous_forest': {u'bod': 0.0,
+                                                           u'cell_count': 72,
+                                                           u'et': 0.14489999999999997,
+                                                           u'inf': 0.8391,
+                                                           u'runoff': 0.0,
+                                                           u'tn': 0.0,
+                                                           u'tp': 0.0,
+                                                           u'tss': 0.0},
+                                   u'c:developed_high': {u'bod': 28.342317499361275,
+                                                         u'cell_count': 42,
+                                                         u'et': 0.012322664565942195,
+                                                         u'inf': 0.0,
+                                                         u'runoff': 0.9716773354340579,
+                                                         u'tn': 0.2079960397130545,
+                                                         u'tp': 0.03291365903151632,
+                                                         u'tss': 5.780461367410053},
+                                   u'd:developed_med': {u'bod': 14.770774289378844,
+                                                        u'cell_count': 33,
+                                                        u'et': 0.037259999999999995,
+                                                        u'inf': 0.26946506358880085,
+                                                        u'runoff': 0.6772749364111992,
+                                                        u'tn': 0.08574559651037718,
+                                                        u'tp': 0.014395246129479379,
+                                                        u'tss': 1.764982351527472}},
+                 u'et': 0.08285667967190184,
+                 u'inf': 0.47147991223422064,
+                 u'runoff': 0.4296634080938776,
+                 u'tn': 0.2937416362234317,
+                 u'tp': 0.0473089051609957,
+                 u'tss': 7.545443718937525}
 ```
 
 The output shown is a tree-like dictionary, akin to the one in the discussion of the first parameter of the `simulate_water_quality` function, except with additional keys and values attached to each  node in the tree.  The additional keys, `runoff`, `tss`, and so on, have associated values which are the water volumes and pollutant loads that have been calculated.  The volumes and loads at the leaves of the tree are those returned by the `fn` function (the second parameter of the `simulate_modifications` function), while those of internal nodes are the sums of the amounts found in their child nodes.

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1418,6 +1418,28 @@ class TestModel(unittest.TestCase):
         self.assertRaises(ValueError,
                           simulate_day, *(census, precip))
 
+    def test_greenroof_runoff(self):
+        """
+        Make sure that the green roof BMP does not produce negative
+        runoff.
+        """
+        census = {
+            "cell_count": 1,
+            "distribution": {
+                "d:developed_med": {"cell_count": 1}
+            },
+            "modifications": [
+                {
+                    "change": "::green_roof",
+                    "cell_count": 1,
+                    "distribution": {
+                        "d:developed_med": {"cell_count": 1}
+                    }
+                }
+            ]
+        }
+        result = simulate_day(census, 0.984)
+        self.assertTrue(result['modified']['runoff'] >= 0)
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1418,10 +1418,9 @@ class TestModel(unittest.TestCase):
         self.assertRaises(ValueError,
                           simulate_day, *(census, precip))
 
-    def test_greenroof_runoff(self):
+    def test_bmp_runoff(self):
         """
-        Make sure that the green roof BMP does not produce negative
-        runoff.
+        Make sure that BMPs do not produce negative runoff.
         """
         census = {
             "cell_count": 1,
@@ -1440,6 +1439,35 @@ class TestModel(unittest.TestCase):
         }
         result = simulate_day(census, 0.984)
         self.assertTrue(result['modified']['runoff'] >= 0)
+
+    def test_bmp_sum(self):
+        """
+        Make sure that runoff, evapotranspiration, and infiltration sum to
+        precipitation.
+        """
+        census = {
+            "cell_count": 1,
+            "distribution": {
+                "d:developed_med": {"cell_count": 1}
+            },
+            "modifications": [
+                {
+                    "change": "::green_roof",
+                    "cell_count": 1,
+                    "distribution": {
+                        "d:developed_med": {"cell_count": 1}
+                    }
+                }
+            ]
+        }
+
+        precip = 0.984
+        result = simulate_day(census, precip)
+        runoff = result['modified']['runoff']
+        et = result['modified']['et']
+        inf = result['modified']['inf']
+        total = runoff + et +inf
+        self.assertAlmostEqual(total, precip)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tr55/model.py
+++ b/tr55/model.py
@@ -105,6 +105,25 @@ def simulate_cell_day(precip, evaptrans, cell, cell_count):
     The return value is a dictionary of runoff, evapotranspiration, and
     infiltration as volumes of water.
     """
+    def clamp(runoff, et, inf, precip):
+        """
+        This function clamps ensures that runoff + et + inf <= precip.
+
+        NOTE: infiltration is normally independent of the
+        precipitation level, but this function introduces a slight
+        dependency (that is, at very low levels of precipitation, this
+        function can cause infiltration to be smaller than it
+        ordinarily would be.
+        """
+        total = runoff + et + inf
+        if (total > precip):
+            scale = precip / total
+            runoff *= scale
+            et *= scale
+            inf *= scale
+        return (runoff, et, inf)
+
+    precip = max(0.0, precip)
     soil_type, land_use, bmp = cell.lower().split(':')
 
     # If there is no precipitation, then there is no runoff or
@@ -114,8 +133,9 @@ def simulate_cell_day(precip, evaptrans, cell, cell_count):
     if precip == 0.0:
         return {
             'runoff-vol': 0.0,
-            'et-vol': cell_count * evaptrans,
-            'inf-vol': 0.0
+            # 'et-vol': cell_count * evaptrans,
+            'et-vol': 0.0,
+            'inf-vol': 0.0,
         }
 
     # Deal with the Best Management Practices (BMPs).  For most BMPs,
@@ -125,6 +145,7 @@ def simulate_cell_day(precip, evaptrans, cell, cell_count):
     if bmp and is_bmp(bmp) and bmp != 'rain_garden':
         inf = lookup_bmp_infiltration(soil_type, bmp)  # infiltration
         runoff = max(0.0, precip - (evaptrans + inf))  # runoff
+        (runoff, evaptrans, inf) = clamp(runoff, evaptrans, inf, precip)
         return {
             'runoff-vol': cell_count * runoff,
             'et-vol': cell_count * evaptrans,
@@ -140,10 +161,15 @@ def simulate_cell_day(precip, evaptrans, cell, cell_count):
         hir_run = hi_res['runoff-vol']
         hir_et = hi_res['et-vol']
         hir_inf = hi_res['inf-vol']
+        final_runoff = (0.2 * runoff + 0.8 * hir_run)
+        final_et = (0.2 * evaptrans + 0.8 * hir_et)
+        final_inf = (0.2 * inf + 0.8 * hir_inf)
+        final = clamp(final_runoff, final_et, final_inf, precip)
+        (final_runoff, final_et, final_inf) = final
         return {
-            'runoff-vol': cell_count * (0.2 * runoff + 0.8 * hir_run),
-            'et-vol': cell_count * (0.2 * evaptrans + 0.8 * hir_et),
-            'inf-vol': cell_count * (0.2 * inf + 0.8 * hir_inf)
+            'runoff-vol': cell_count * final_runoff,
+            'et-vol': cell_count * final_et,
+            'inf-vol': cell_count * final_inf
         }
 
     # At this point, if the `bmp` string has non-zero length, it is
@@ -167,6 +193,7 @@ def simulate_cell_day(precip, evaptrans, cell, cell_count):
         runoff = runoff_nrcs(precip, evaptrans, soil_type, land_use)
     inf = max(0.0, precip - (evaptrans + runoff))
 
+    (runoff, evaptrans, inf) = clamp(runoff, evaptrans, inf, precip)
     return {
         'runoff-vol': cell_count * runoff,
         'et-vol': cell_count * evaptrans,


### PR DESCRIPTION
Two things are done:

   *  Since the runoff for BMPs is calculated by subtracting the sum of a fixed infiltration value read from a table and the evapotranspiration from the precipitation, it is possible to get a negative runoff.  The runoff is now the maximum of zero and the difference just mentioned.
   * This forces runoff + evapotranspiration + infiltration to match the precipitation level for that day by scaling them proportionally if they do not.

**To test**
   * Run the TR-55 unit tests, two new test cases have been added for the two items mentioned above.
   * Run the code in MMW:
      * SSH into the `worker` and the `app` and type `sudo pip uninstall tr55` then `sudo pip install 'git+https://github.com/jamesmcclain/tr-55.git@bug/bmp-runoff'`.  (I think it is only necessary to do this on the `worker`, but I always do it on both.)
      * Go to a scenario, set the precipitation level to 2.5 cm, and cover the AoI with a large Green Roof.  Both the "current conditions" and the "modified" graphs should be the same height, they were not before.

Connects WikiWatershed/model-my-watershed#895