### PR TITLE
Verify census is valid before running model.

### DIFF
--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1390,5 +1390,34 @@ class TestModel(unittest.TestCase):
         expected = DAY_OUTPUT_2
         self.assertEqual(actual, expected)
 
+    def test_day_with_invalid_census(self):
+        """
+        Test the simulate_day function with a census
+        that has a modification census with a cover type
+        that doesn't exist within the AoI census. This is
+        invalid input. Each land cover type in a modification
+        census must be represented in AoI census.
+        """
+        census = {
+            'distribution': {
+                'b:developed_med': {'cell_count': 400},
+            },
+            'cell_count': 400,
+            'modifications': [
+                {
+                    'distribution': {
+                        'b:developed_low': {'cell_count': 40}
+                    },
+                    'cell_count': 40,
+                    'change': ':deciduous_forest:'
+                },
+            ]
+        }
+
+        precip = 3
+        self.assertRaises(ValueError,
+                          simulate_day, *(census, precip))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tr55/model.py
+++ b/tr55/model.py
@@ -359,6 +359,9 @@ def simulate_day(census, precip, cell_res=10, precolumbian=False):
     """
     et_max = 0.207
 
+    if 'modifications' in census:
+        verify_census(census)
+
     def fn(cell, cell_count):
         split = cell.split(':')
         if (len(split) == 2):
@@ -370,3 +373,14 @@ def simulate_day(census, precip, cell_res=10, precolumbian=False):
         return simulate_cell_day(precip, et, cell, cell_count)
 
     return simulate_modifications(census, fn, cell_res, precolumbian)
+
+
+def verify_census(census):
+    """
+    Assures that there is no soil type/land cover pair
+    in a modification census that isn't in the AoI census.
+    """
+    for modification in census['modifications']:
+        for land_cover in modification['distribution']:
+            if land_cover not in census['distribution']:
+                raise ValueError("Invalid modification census")


### PR DESCRIPTION
* Test that any modification censuses are valid by making sure
they only contain soil/land cover pairs that are in the AoI census.

**Testing instructions**
- Run the tests.

Refs https://github.com/WikiWatershed/model-my-watershed/issues/846