### PR TITLE
D-Type Infiltration Values for BMPs

### DIFF
--- a/test/test_model.py
+++ b/test/test_model.py
@@ -1469,5 +1469,57 @@ class TestModel(unittest.TestCase):
         total = runoff + et +inf
         self.assertAlmostEqual(total, precip)
 
+    def test_bmps_on_d(self):
+        """
+        Make sure that BMPS all work on soil type D.
+        """
+        census = {
+            "cell_count": 2,
+            "distribution": {
+                "c:developed_med": {"cell_count": 1},
+                "d:developed_med": {"cell_count": 1}
+            },
+            "modifications": [
+                {
+                    "change": "::porous_paving",
+                    "cell_count": 1,
+                    "distribution": {
+                        "c:developed_med": {"cell_count": 1}
+                    }
+                },
+                {
+                    "change": "::porous_paving",
+                    "cell_count": 1,
+                    "distribution": {
+                        "d:developed_med": {"cell_count": 1}
+                    }
+                }
+            ]
+        }
+
+        # Porous Paving
+        precip = 3.3
+        result = simulate_day(census, precip)
+        c_inf = result['modified']['distribution']['c:developed_med']['inf']
+        d_inf = result['modified']['distribution']['d:developed_med']['inf']
+        self.assertAlmostEqual(c_inf / 3, d_inf)
+
+        # Rain Garden
+        census['modifications'][0]['change'] = '::rain_garden'
+        census['modifications'][1]['change'] = '::rain_garden'
+        result = simulate_day(census, precip)
+        c_inf = result['modified']['distribution']['c:developed_med']['inf']
+        d_inf = result['modified']['distribution']['d:developed_med']['inf']
+        self.assertLess(d_inf, c_inf)
+        self.assertGreater(d_inf / c_inf, 0.5)
+
+        # Infiltration Trench
+        census['modifications'][0]['change'] = '::infiltration_trench'
+        census['modifications'][1]['change'] = '::infiltration_trench'
+        result = simulate_day(census, precip)
+        c_inf = result['modified']['distribution']['c:developed_med']['inf']
+        d_inf = result['modified']['distribution']['d:developed_med']['inf']
+        self.assertAlmostEqual(c_inf / 3, d_inf)
+
 if __name__ == "__main__":
     unittest.main()

--- a/tr55/tables.py
+++ b/tr55/tables.py
@@ -30,9 +30,12 @@ LAND_USE_VALUES = {
     'herbaceous_wetlands':  {'nlcd': 95, 'ki': 1, 'cn': {'a': 98, 'b': 98, 'c': 98, 'd': 98}},  # noqa
 
     'green_roof':           {'ki': 0.4, 'infiltration': {'a': 1.6, 'b': 1.6, 'c': 1.6, 'd': 1.6}},  # noqa
-    'porous_paving':        {'ki': 0.0, 'infiltration': {'a': 7.73, 'b': 4.13, 'c': 1.73}},  # noqa
-    'rain_garden':          {'ki': 0.08, 'infiltration': {'a': 1.2, 'b': 0.6, 'c': 0.2}},  # noqa
-    'infiltration_trench':  {'ki': 0.0, 'infiltration': {'a': 2.4, 'b': 1.8, 'c': 1.4}},  # noqa
+    # The infiltration amounts for Porous Paving, Rain Gardens, and
+    # Infiltration Trenches on soil type D are typically one-third of
+    # what they are on soil type C.
+    'porous_paving':        {'ki': 0.0, 'infiltration': {'a': 7.73, 'b': 4.13, 'c': 1.73, 'd': (1.73 / 3)}},  # noqa
+    'rain_garden':          {'ki': 0.08, 'infiltration': {'a': 1.2, 'b': 0.6, 'c': 0.2, 'd': (0.2 / 3)}},  # noqa
+    'infiltration_trench':  {'ki': 0.0, 'infiltration': {'a': 2.4, 'b': 1.8, 'c': 1.4, 'd': (1.4 / 3)}},  # noqa
     'cluster_housing':      {'ki': 0.42},
     'no_till':              {'ki': 0.9, 'cn': {'a': 57, 'b': 73, 'c': 82, 'd': 86}}  # noqa
 }


### PR DESCRIPTION
The infiltration amounts for *Porous Paving*, *Rain Gardens*, and *Infiltration Trenches* on soil D have been set to 1/3 of those on soil C.

Because the Rain Garden is actually a mixture of 80% high-intensity residential and 20% ideal rain garden, it is not generally the case that the ratios of the infiltration values are 1:3 on D- versus C-type soil. The exact ratio may also fail to occur when the infiltration value has been reduced (as when the precipitation is low).

Connects #34

**To Test**
   * Run the tests