### PR TITLE
Replace generic exceptions with KeyErrors.

### DIFF
--- a/tr55/model.py
+++ b/tr55/model.py
@@ -175,7 +175,7 @@ def simulate_cell_day(precip, evaptrans, cell, cell_count):
     # At this point, if the `bmp` string has non-zero length, it is
     # equal to either 'no_till' or 'cluster_housing'.
     if bmp and bmp != 'no_till' and bmp != 'cluster_housing':
-        raise Exception('Unexpected BMP: %s' % bmp)
+        raise KeyError('Unexpected BMP: %s' % bmp)
     land_use = bmp or land_use
 
     # When the land use is a built-type and the level of precipitation

--- a/tr55/tablelookup.py
+++ b/tr55/tablelookup.py
@@ -16,9 +16,9 @@ def lookup_ki(land_use):
     Lookup the landuse coefficient.
     """
     if land_use not in LAND_USE_VALUES:
-        raise Exception('Unknown land use: %s' % land_use)
+        raise KeyError('Unknown land use: %s' % land_use)
     elif 'ki' not in LAND_USE_VALUES[land_use]:
-        raise Exception('No ki for land use %s' % land_use)
+        raise KeyError('No ki for land use %s' % land_use)
     else:
         return LAND_USE_VALUES[land_use]['ki']
 
@@ -28,11 +28,11 @@ def lookup_bmp_infiltration(soil_type, bmp):
     Lookup the amount of infiltration caused by a particular BMP.
     """
     if bmp not in LAND_USE_VALUES:
-        raise Exception('%s not a BMP' % bmp)
+        raise KeyError('%s not a BMP' % bmp)
     elif 'infiltration' not in LAND_USE_VALUES[bmp]:
-        raise Exception('No infiltration value for BMP %s' % bmp)
+        raise KeyError('No infiltration value for BMP %s' % bmp)
     elif soil_type not in LAND_USE_VALUES[bmp]['infiltration']:
-        raise Exception('BMP %s incompatible with soil %s' % (bmp, soil_type))
+        raise KeyError('BMP %s incompatible with soil %s' % (bmp, soil_type))
     else:
         return LAND_USE_VALUES[bmp]['infiltration'][soil_type]
 
@@ -42,11 +42,11 @@ def lookup_cn(soil_type, land_use):
     Lookup the runoff curve number for a particular soil type and land use.
     """
     if land_use not in LAND_USE_VALUES:
-        raise Exception('Unknown land use: %s' % land_use)
+        raise KeyError('Unknown land use: %s' % land_use)
     elif 'cn' not in LAND_USE_VALUES[land_use]:
-        raise Exception('No curve numbers for land use %s' % land_use)
+        raise KeyError('No curve numbers for land use %s' % land_use)
     elif soil_type not in LAND_USE_VALUES[land_use]['cn']:
-        raise Exception('Unknown soil type: %s' % soil_type)
+        raise KeyError('Unknown soil type: %s' % soil_type)
     else:
         return LAND_USE_VALUES[land_use]['cn'][soil_type]
 
@@ -81,9 +81,9 @@ def lookup_load(nlcd_class, pollutant):
     class `nlcd_class`
     """
     if pollutant not in ['tn', 'tp', 'bod', 'tss']:
-        raise Exception('Unknown pollutant type: %s' % pollutant)
+        raise KeyError('Unknown pollutant type: %s' % pollutant)
     elif nlcd_class not in POLLUTION_LOADS:
-        raise Exception('Unknown NLCD class: %s' % nlcd_class)
+        raise KeyError('Unknown NLCD class: %s' % nlcd_class)
     else:
         return POLLUTION_LOADS[nlcd_class][pollutant]
 
@@ -93,9 +93,9 @@ def lookup_nlcd(land_use):
     Get the NLCD number for a particular human-readable land use.
     """
     if land_use not in LAND_USE_VALUES:
-        raise Exception('Unknown land use type: %s' % land_use)
+        raise KeyError('Unknown land use type: %s' % land_use)
     elif 'nlcd' not in LAND_USE_VALUES[land_use]:
-        raise Exception('Land use type %s does not have an NLCD class defined',
+        raise KeyError('Land use type %s does not have an NLCD class defined',
                         land_use)
     else:
         return LAND_USE_VALUES[land_use]['nlcd']


### PR DESCRIPTION
Related to https://github.com/WikiWatershed/model-my-watershed/issues/976

Rather than raising generic Exceptions, raise KeyErrors which generally match
the behavior of our application which has lists of allowed values.

### To test:
Provide a bad key to a process that runs tr55 and watch the logs for the raised exception.