### PR TITLE
Prevent error when no runoff present

### DIFF
--- a/test/test_model.py
+++ b/test/test_model.py
@@ -12,7 +12,7 @@ import unittest
 from tr55.model import runoff_nrcs, \
     simulate_cell_day, simulate_water_quality, \
     create_unmodified_census, create_modified_census, \
-    simulate_day
+    simulate_day, compute_bmp_effect
 from tr55.tablelookup import lookup_ki
 
 # These data are taken directly from Table 2-1 of the revised (1986)
@@ -856,6 +856,20 @@ class TestModel(unittest.TestCase):
         inf = result['modified']['inf']
         total = runoff + et + inf
         self.assertAlmostEqual(total, precip)
+
+    def test_compute_bmp_no_runoff(self):
+        """
+        Test that no runoff will not produce errors when computing BMP effects
+        """
+        census = {
+            'runoff-vol': 0,
+            'BMPs': {
+                'green_roof': 1942
+            }
+        }
+
+        # No exception should be raised, no bmp effect given
+        self.assertEqual(0, compute_bmp_effect(census, 42))
 
 if __name__ == "__main__":
     unittest.main()

--- a/tr55/model.py
+++ b/tr55/model.py
@@ -334,7 +334,9 @@ def compute_bmp_effect(census, m2_per_pixel):
     for bmp in set.intersection(set(get_bmps()), bmp_keys):
         bmp_area = bmp_dict[bmp]
         reduction += lookup_bmp_storage(bmp) * bmp_area
-    return max(0.0, cubic_meters - reduction) / cubic_meters
+
+    return 0 if not cubic_meters else \
+        max(0.0, cubic_meters - reduction) / cubic_meters
 
 
 def simulate_modifications(census, fn, cell_res, pc=False):


### PR DESCRIPTION
No runoff caused a division by zero error when computing the effect of a
bmp since it was dividing by a volume of runoff.  Assumes that no runoff
means that no bmp effect is produced.

Test:  Ensure the new test passes, for runoff at 0.

/cc @jamesmcclain 