### PR TITLE
Update Green Roof BMP storage amount

### DIFF
--- a/test/test_tablelookup.py
+++ b/test/test_tablelookup.py
@@ -20,7 +20,7 @@ class TestTablelookups(unittest.TestCase):
         """
         Do some spot-checks on the data from Table B.
         """
-        self.assertEqual(lookup_bmp_storage('green_roof'), 0.396)
+        self.assertEqual(lookup_bmp_storage('green_roof'), 0.020)
         self.assertEqual(lookup_bmp_storage('infiltration_trench'), 0.610)  # noqa
         self.assertEqual(lookup_bmp_storage('porous_paving'), 0.267)
         self.assertEqual(lookup_bmp_storage('rain_garden'), 0.396)

--- a/tr55/tables.py
+++ b/tr55/tables.py
@@ -33,7 +33,7 @@ LAND_USE_VALUES = {
     'no_till':              {'ki': 0.9, 'cn': {'a': 57, 'b': 73, 'c': 82, 'd': 86}},  # noqa
 
     # BMP storage capacities
-    'green_roof':           {'ki': 0.4,  'storage': 0.396},
+    'green_roof':           {'ki': 0.4,  'storage': 0.020},
     'infiltration_trench':  {'ki': 0.0,  'storage': 0.610},
     'porous_paving':        {'ki': 0.0,  'storage': 0.267},
     'rain_garden':          {'ki': 0.08, 'storage': 0.396},


### PR DESCRIPTION
A typo in the original implementation had Green Roof BMPs being too
effective at reducing runoff (h/t @SRGDamia1 for finding the typo).

#### To test:
* Ensure that the python tests on the PR pass
* Ensure that the updated value for Green Roof matches the Available volume for water storage per unit BMP area on the [Land Use Parameter Documentation](https://docs.google.com/spreadsheets/d/1qgWUKtEFWxdRfmwo1_RCUj7-OzzIU86CaZbA54sNFR0/edit#gid=1205327723)

